### PR TITLE
feat: add retrospective documents for Unit 1 and Unit 2

### DIFF
--- a/.github/ISSUE_TEMPLATE/sub-feature.md
+++ b/.github/ISSUE_TEMPLATE/sub-feature.md
@@ -1,3 +1,10 @@
+---
+name: Subtask
+about: Crie uma sub-tarefa para uma feature (Sub-feature)
+title: "ST-F##.# — "
+labels: "subtask"
+assignees: ""
+---
 ## Subtask
 **Feature pai:** [F## — Título]
 

--- a/gh-pages/docs/visao/10-licoes/10-1.md
+++ b/gh-pages/docs/visao/10-licoes/10-1.md
@@ -48,10 +48,14 @@ Esta seção registra as **lições aprendidas** ao longo da primeira unidade do
 
 | Ação | Responsável | Prazo |
 |------|-------------|-------|
-| Criar templates de issues e PRs no GitHub | Tech Lead | Início da Sprint 1 |
-| Mapear disponibilidade da equipe para a Sprint 1 | Tech Lead | Início da Sprint 1 |
-| Validar processo de commits individuais com monitoria | TechLead | 14/04/2026 |
-| Revisar e fechar backlog inicial com PO | Tech Lead | Sprint 1 Planning |
-| Configurar GitHub Projects com board Scrumban | Tech Lead | Início da Sprint 1 |
-| Documentar guia de setup do ambiente de desenvolvimento | Tech Lead | Sprint 1 — Semana 1 |
-| Registrar contato secundário na Crianex para decisões urgentes | TechLead | Início da Sprint 1 |
+| Criar templates de issues e PRs no GitHub | PM | Semana 1 |
+| Mapear disponibilidade da equipe | PM  | Semana 1 |
+| Validar processo de commits individuais | TechLead e PM | --- |
+| Revisar e fechar backlog inicial com priorização | PM | Semana 2 |
+| Configurar GitHub Projects com board Kanban | Tech Lead | Semana 1 |
+| Documentar guia de setup do ambiente de desenvolvimento | Tech Lead | Semana 3 |
+| Criar diagramas de sequencia do Technical Design review | TechLead | Semana 2 |
+| Criar protótipo de alta fidelidade e validar com o cliente | PM | Semana 2 |
+| Desenvolver a solução proposta da iteração 1 | Todos | Semana 4 |
+
+

--- a/gh-pages/docs/visao/10-licoes/10-2.md
+++ b/gh-pages/docs/visao/10-licoes/10-2.md
@@ -1,0 +1,50 @@
+# 10.2 Lições Aprendidas
+
+---
+
+## Histórico de Revisão
+
+| Versão | Data | Descrição | Autor(es) |
+|--------|------|-----------|-----------|
+| 1.0 | 18/05/2026 | Criação da retrospectiva da Unidade 2 — IT1 Vitrine Pública | Lucas A. Zanetti |
+
+---
+
+## Retrospectiva da Unidade 2 — IT2: Vitrine Pública
+
+Esta seção registra as **lições aprendidas** ao longo da segunda unidade do projeto Crianex (IT2 — Vitrine Pública), com foco na consolidação dos requisitos, estruturação do backlog e alinhamento da aplicação da metodologia FDD.
+
+---
+
+## Tabela de Lições Aprendidas
+
+| Categoria | Lição Aprendida | Ação Corretiva |
+|-----------|-----------------|----------------|
+| **Processo e Metodologia** | A Engenharia de Requisitos descrevia as cerimônias das etapas 1–3 do FDD como se fossem iterativas, gerando confusão sobre o que se repete a cada iteração e o que ocorre somente no início do projeto | Reescrever a seção 4 separando explicitamente etapas únicas (1–3) das etapas iterativas (4–5); deixar claro no processo que Domain Modeling, Feature Discovery e Plan by Feature são fundação única do projeto |
+| **Entregas em Sala** | Tivemos que mudar nosso modelo de captação de requisitos, para atender as necessidade da matéria de requisitos, uma vez que o professor exigiu todos os requisitos prontos e rastráveis para a apresentação | Fizemos uma reunião rápida com o cliente para para ouvir as necessidades e desejos das CPs de outras iterações e então poder montar a rastreabilidade delas |
+| **Rastreabilidade** | A numeração e os nomes das Características de Produto (CPs) apresentavam inconsistências entre o arquivo `solucao.md` e o `rastreabilidade.md`, causando divergência nos mapeamentos de features e RFs | Definir um único arquivo como fonte da verdade para cada tipo de artefato e registrá-lo explicitamente no CLAUDE.md; qualquer atualização deve ser propagada a partir da fonte, não feita isoladamente em cada arquivo |
+| **Backlog e Requisitos** | O backlog foi estruturado inicialmente com Épicos e User Stories ao invés do formato FDD (Feature Sets → Features → RFs com rastreabilidade OE→CP→Feature→RF) | Restruturar o backlog seguindo a hierarquia FDD com Feature List, tabela de RFs rastreáveis e cenários BDD; usar a `rastreabilidade.md` como documento central |
+| **Backlog e Requisitos** | As iterações dentro do backlog tinham mapeamentos de CPs incorretos, divergindo do cronograma oficial definido em `cronograma.md` | Sempre consultar `cronograma.md` como fonte da verdade para a distribuição de CPs por iteração; não preencher iterações no backlog sem confirmar com o cronograma |
+| **Gestão do Tempo** | A organização dos artefatos de documentação (er.md, backlog, iterações) foi deixada para o final da unidade, gerando acúmulo de ajustes no prazo de entrega | Definir no Iteration Commitment quais artefatos de documentação precisam ser atualizados e atribuir responsáveis com prazo intermediário, não apenas no Artifact Closure |
+
+---
+
+## O que foi bem
+
+| # | Ponto positivo |
+|---|----------------|
+| 1 | A infraestrutura de documentação (MkDocs, GitHub Pages, estrutura de pastas) funcionou de forma estável durante toda a unidade |
+| 2 | A tabela de rastreabilidade OE → CP → Feature → RF/RNF foi construída de forma completa e coerente, cobrindo todos os 47 RFs e 24 RNFs do produto |
+| 3 | A separação da lição aprendida sobre as etapas únicas vs. iterativas do FDD aumentou a clareza do processo para toda a equipe |
+| 4 | A estrutura de evidências de entrega foi adicionada a todas as iterações, preparando o registro formal de validações para as próximas entregas |
+| 5 | O contexto do projeto foi organizado e segmentado adequadamente, facilitando o trabalho incremental nas próximas iterações |
+
+---
+
+## Ações até a Próxima Unidade — IT2: Lead Capture
+
+| Ação | Responsável | Prazo |
+|------|-------------|-------|
+| Continuar a IT1 entregando as funcionalidades | Todos | 25/05 |
+| Dar andamento as cerimônias da IT2 e realizar as entregas iterativas| Todos | --- |
+

--- a/gh-pages/mkdocs.yml
+++ b/gh-pages/mkdocs.yml
@@ -32,7 +32,9 @@ nav:
     - "4 · Eng. de Requisitos": visao/er.md
     - "5 · Cronograma": visao/cronograma.md
     - "6 · Equipe e Interação": visao/equipe.md
-    - "Lições Aprendidas": visao/10-licoes/index.md
+    - Lições Aprendidas:
+      - "10.1 · Unidade 1": visao/10-licoes/10-1.md
+      - "10.2 · Unidade 2": visao/10-licoes/10-2.md
   - Iterações:
     - "Visão Geral": iteracoes/index.md
     - "Unidade 1":


### PR DESCRIPTION
This pull request introduces significant improvements to the documentation structure and project management templates, focusing on the lessons learned and team workflow. The main changes include the addition of a new subtask issue template, the creation and reorganization of the "Lições Aprendidas" (Lessons Learned) documentation into unit-specific files, updates to the navigation menu, and a revision of the action items and responsibilities in the lessons learned section for greater clarity and accuracy.

**Documentation Improvements:**

* Added a new file `gh-pages/docs/visao/10-licoes/10-2.md` containing the lessons learned, retrospective, and action items for Unit 2, including a structured table of lessons, positive points, and next steps.
* Renamed and updated `gh-pages/docs/visao/10-licoes/index.md` to `10-1.md`, revising the action items table to clarify responsibilities, deadlines, and to reflect the actual process followed by the team.
* Updated the navigation in `gh-pages/mkdocs.yml` to split "Lições Aprendidas" into two sub-sections for Unit 1 and Unit 2, improving discoverability and organization.

**Project Management Enhancements:**

* Added a new GitHub issue template `.github/ISSUE_TEMPLATE/sub-feature.md` for creating subtasks, standardizing sub-feature tracking and assignment.