### PR TITLE
feat: create leads table with minimum data fields and LGPD compliance

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -7,8 +7,8 @@
     "dev": "tsx watch --env-file=../.env src/index.ts",
     "build": "tsc",
     "start": "node dist/index.js",
-    "test": "node --env-file=../.env ../node_modules/.bin/vitest run",
-    "test:watch": "node --env-file=../.env ../node_modules/.bin/vitest",
+    "test": "vitest run",
+    "test:watch": "vitest",
     "lint": "eslint .",
     "typecheck": "tsc --noEmit"
   },

--- a/backend/package.json
+++ b/backend/package.json
@@ -7,8 +7,8 @@
     "dev": "tsx watch --env-file=../.env src/index.ts",
     "build": "tsc",
     "start": "node dist/index.js",
-    "test": "vitest run",
-    "test:watch": "vitest",
+    "test": "node --env-file=../.env ../node_modules/.bin/vitest run",
+    "test:watch": "node --env-file=../.env ../node_modules/.bin/vitest",
     "lint": "eslint .",
     "typecheck": "tsc --noEmit"
   },

--- a/backend/src/lib/leads.test.ts
+++ b/backend/src/lib/leads.test.ts
@@ -1,0 +1,105 @@
+import { describe, it, expect, afterEach, beforeAll } from 'vitest';
+import { createClient, type SupabaseClient } from '@supabase/supabase-js';
+
+const SUPABASE_URL = process.env['SUPABASE_URL'] ?? 'http://localhost:54321';
+const ANON_KEY = process.env['PUBLIC_SUPABASE_PUBLISHABLE_KEY'] ?? '';
+const SERVICE_KEY = process.env['SUPABASE_SECRET_KEY'] ?? '';
+
+const hasConfig = !!ANON_KEY && !!SERVICE_KEY;
+
+let anon: SupabaseClient;
+let admin: SupabaseClient;
+
+const TEST_EMAIL = 'vitest-leads@test.invalid';
+
+const validLead = {
+  name: 'Test Lead',
+  email: TEST_EMAIL,
+  message: 'Interested in product X',
+  ip_hash: 'a'.repeat(64),
+};
+
+beforeAll(() => {
+  if (!hasConfig) return;
+  anon = createClient(SUPABASE_URL, ANON_KEY);
+  admin = createClient(SUPABASE_URL, SERVICE_KEY, {
+    auth: { autoRefreshToken: false, persistSession: false },
+  });
+});
+
+afterEach(async () => {
+  if (!hasConfig) return;
+  await admin.from('leads').delete().eq('email', TEST_EMAIL);
+});
+
+describe.skipIf(!hasConfig)('leads — insert (anon)', () => {
+  it('aceita lead válido', async () => {
+    const { error } = await anon.from('leads').insert(validLead);
+    expect(error).toBeNull();
+  });
+
+  it('rejeita sem ip_hash (NOT NULL)', async () => {
+    const { name, email, message } = validLead;
+    const { error } = await anon.from('leads').insert({ name, email, message });
+    expect(error).not.toBeNull();
+    expect(error!.code).toBe('23502');
+  });
+
+  it('rejeita status inválido (CHECK)', async () => {
+    const { error } = await anon.from('leads').insert({ ...validLead, status: 'spam' });
+    expect(error).not.toBeNull();
+    expect(error!.code).toBe('23514');
+  });
+
+  it('rejeita sem name (NOT NULL)', async () => {
+    const { email, message, ip_hash } = validLead;
+    const { error } = await anon.from('leads').insert({ email, message, ip_hash });
+    expect(error).not.toBeNull();
+    expect(error!.code).toBe('23502');
+  });
+
+  it('rejeita sem message (NOT NULL)', async () => {
+    const { name, email, ip_hash } = validLead;
+    const { error } = await anon.from('leads').insert({ name, email, ip_hash });
+    expect(error).not.toBeNull();
+    expect(error!.code).toBe('23502');
+  });
+
+  it('status default é "new"', async () => {
+    await anon.from('leads').insert(validLead);
+    const { data } = await admin.from('leads').select('status').eq('email', TEST_EMAIL).single();
+    expect(data?.status).toBe('new');
+  });
+
+  it('aceita status "archived"', async () => {
+    const { error } = await anon.from('leads').insert({ ...validLead, status: 'archived' });
+    expect(error).toBeNull();
+  });
+});
+
+describe.skipIf(!hasConfig)('leads — select (RLS)', () => {
+  it('anon não pode SELECT (REVOKE + RLS)', async () => {
+    const { error } = await anon.from('leads').select('*');
+    expect(error).not.toBeNull();
+  });
+
+  it('service_role pode SELECT (bypass RLS)', async () => {
+    await admin.from('leads').insert(validLead);
+    const { data, error } = await admin.from('leads').select('*').eq('email', TEST_EMAIL);
+    expect(error).toBeNull();
+    expect(data!.length).toBeGreaterThan(0);
+  });
+
+  it('lead inserido contém os campos esperados', async () => {
+    await anon.from('leads').insert(validLead);
+    const { data } = await admin
+      .from('leads')
+      .select('id, name, email, message, ip_hash, status, created_at')
+      .eq('email', TEST_EMAIL)
+      .single();
+    expect(data?.id).toBeTruthy();
+    expect(data?.name).toBe(validLead.name);
+    expect(data?.ip_hash).toBe(validLead.ip_hash);
+    expect(data?.created_at).toBeTruthy();
+  });
+});

--- a/backend/vitest.config.ts
+++ b/backend/vitest.config.ts
@@ -1,14 +1,19 @@
 import { defineConfig } from 'vitest/config';
+import { loadEnv } from 'vite';
 
-export default defineConfig({
-  test: {
-    include: ['src/**/*.{test,spec}.ts'],
-    environment: 'node',
-    coverage: {
-      provider: 'v8',
-      reporter: ['text', 'lcov'],
-      include: ['src/**/*.ts'],
-      exclude: ['src/**/*.{test,spec}.ts', 'src/index.ts'],
+export default defineConfig(({ mode }) => {
+  const env = loadEnv(mode ?? 'test', '..', '');
+  return {
+    test: {
+      include: ['src/**/*.{test,spec}.ts'],
+      environment: 'node',
+      env,
+      coverage: {
+        provider: 'v8',
+        reporter: ['text', 'lcov'],
+        include: ['src/**/*.ts'],
+        exclude: ['src/**/*.{test,spec}.ts', 'src/index.ts'],
+      },
     },
-  },
+  };
 });

--- a/supabase/migrations/20260524201624_create_leads.sql
+++ b/supabase/migrations/20260524201624_create_leads.sql
@@ -28,9 +28,11 @@ CREATE INDEX leads_created_at_idx ON leads (created_at DESC);
 CREATE INDEX leads_ip_hash_idx ON leads (ip_hash);
 
 -- ── Grants ───────────────────────────────────────────────────────────────────
--- Explicit INSERT for anon (lead form); revoke SELECT to hide the table from
--- PostgREST/GraphQL schema introspection for anon and authenticated roles.
+-- INSERT for anon (lead form); SELECT only for service_role (admin queries).
+-- Revoke SELECT from anon/authenticated to hide the table from PostgREST
+-- schema introspection. service_role bypasses RLS but still needs the privilege.
 GRANT INSERT ON leads TO anon;
+GRANT ALL ON leads TO service_role;
 REVOKE SELECT ON leads FROM anon, authenticated;
 
 -- ── RLS ──────────────────────────────────────────────────────────────────────

--- a/supabase/migrations/20260524201624_create_leads.sql
+++ b/supabase/migrations/20260524201624_create_leads.sql
@@ -1,6 +1,7 @@
 -- Migration: create leads table (issue #85 / CP6)
 -- LGPD: minimum data only — no phone, CPF, or raw IP stored.
 -- ip_hash stores SHA-256(ip_address) for rate-limit lookups only.
+-- Legal basis: legitimate interest (art. 7 VI Lei 13.709/2018).
 
 CREATE TABLE leads (
   id               uuid        PRIMARY KEY DEFAULT gen_random_uuid(),
@@ -11,9 +12,14 @@ CREATE TABLE leads (
   message          text        NOT NULL,
   status           text        NOT NULL DEFAULT 'new'
                                CHECK (status IN ('new', 'read', 'archived')),
-  ip_hash          text,
+  ip_hash          text        NOT NULL,
   created_at       timestamptz NOT NULL DEFAULT now()
 );
+
+COMMENT ON TABLE leads IS
+  'Lead captures from public contact form. '
+  'LGPD basis: legitimate interest (art. 7 VI Lei 13.709/2018). '
+  'No raw IP, phone, or CPF stored.';
 
 -- Paginated admin listing (most recent first)
 CREATE INDEX leads_created_at_idx ON leads (created_at DESC);
@@ -22,8 +28,9 @@ CREATE INDEX leads_created_at_idx ON leads (created_at DESC);
 CREATE INDEX leads_ip_hash_idx ON leads (ip_hash);
 
 -- ── Grants ───────────────────────────────────────────────────────────────────
--- Anon may insert (lead form); revoke SELECT so the table is not discoverable
--- via PostgREST/GraphQL by anon or regular authenticated users.
+-- Explicit INSERT for anon (lead form); revoke SELECT to hide the table from
+-- PostgREST/GraphQL schema introspection for anon and authenticated roles.
+GRANT INSERT ON leads TO anon;
 REVOKE SELECT ON leads FROM anon, authenticated;
 
 -- ── RLS ──────────────────────────────────────────────────────────────────────
@@ -35,9 +42,9 @@ CREATE POLICY leads_insert_public
   FOR INSERT
   WITH CHECK (true);
 
--- Only authenticated users with role = 'owner' can read leads.
+-- Only users with app_metadata.role = 'owner' can read leads.
 -- (select auth.jwt()) caches the JWT once per query instead of per row.
 CREATE POLICY leads_select_owner
   ON leads
   FOR SELECT
-  USING ((select auth.jwt()) ->> 'role' = 'owner');
+  USING ((select auth.jwt()) -> 'app_metadata' ->> 'role' = 'owner');

--- a/supabase/migrations/20260524201624_create_leads.sql
+++ b/supabase/migrations/20260524201624_create_leads.sql
@@ -1,0 +1,43 @@
+-- Migration: create leads table (issue #85 / CP6)
+-- LGPD: minimum data only — no phone, CPF, or raw IP stored.
+-- ip_hash stores SHA-256(ip_address) for rate-limit lookups only.
+
+CREATE TABLE leads (
+  id               uuid        PRIMARY KEY DEFAULT gen_random_uuid(),
+  name             text        NOT NULL,
+  email            text        NOT NULL,
+  company          text,
+  product_interest text,
+  message          text        NOT NULL,
+  status           text        NOT NULL DEFAULT 'new'
+                               CHECK (status IN ('new', 'read', 'archived')),
+  ip_hash          text,
+  created_at       timestamptz NOT NULL DEFAULT now()
+);
+
+-- Paginated admin listing (most recent first)
+CREATE INDEX leads_created_at_idx ON leads (created_at DESC);
+
+-- Rate-limit lookup by hashed IP
+CREATE INDEX leads_ip_hash_idx ON leads (ip_hash);
+
+-- ── Grants ───────────────────────────────────────────────────────────────────
+-- Anon may insert (lead form); revoke SELECT so the table is not discoverable
+-- via PostgREST/GraphQL by anon or regular authenticated users.
+REVOKE SELECT ON leads FROM anon, authenticated;
+
+-- ── RLS ──────────────────────────────────────────────────────────────────────
+ALTER TABLE leads ENABLE ROW LEVEL SECURITY;
+
+-- Any visitor (anon) can submit a lead
+CREATE POLICY leads_insert_public
+  ON leads
+  FOR INSERT
+  WITH CHECK (true);
+
+-- Only authenticated users with role = 'owner' can read leads.
+-- (select auth.jwt()) caches the JWT once per query instead of per row.
+CREATE POLICY leads_select_owner
+  ON leads
+  FOR SELECT
+  USING ((select auth.jwt()) ->> 'role' = 'owner');

--- a/supabase/tests/leads_test.sql
+++ b/supabase/tests/leads_test.sql
@@ -1,0 +1,87 @@
+-- pgTAP tests for leads table (issue #85 / CP6)
+-- Run with: supabase test db
+BEGIN;
+
+SELECT plan(24);
+
+-- ── Schema ────────────────────────────────────────────────────────────────────
+
+SELECT has_table('public', 'leads', 'leads table exists');
+
+SELECT has_column('public', 'leads', 'id',               'has id');
+SELECT has_column('public', 'leads', 'name',             'has name');
+SELECT has_column('public', 'leads', 'email',            'has email');
+SELECT has_column('public', 'leads', 'company',          'has company');
+SELECT has_column('public', 'leads', 'product_interest', 'has product_interest');
+SELECT has_column('public', 'leads', 'message',          'has message');
+SELECT has_column('public', 'leads', 'status',           'has status');
+SELECT has_column('public', 'leads', 'ip_hash',          'has ip_hash');
+SELECT has_column('public', 'leads', 'created_at',       'has created_at');
+
+-- ── NOT NULL constraints ──────────────────────────────────────────────────────
+
+SELECT col_not_null('public', 'leads', 'name',       'name is NOT NULL');
+SELECT col_not_null('public', 'leads', 'email',      'email is NOT NULL');
+SELECT col_not_null('public', 'leads', 'message',    'message is NOT NULL');
+SELECT col_not_null('public', 'leads', 'ip_hash',    'ip_hash is NOT NULL');
+SELECT col_not_null('public', 'leads', 'status',     'status is NOT NULL');
+SELECT col_not_null('public', 'leads', 'created_at', 'created_at is NOT NULL');
+
+-- ── RLS & policies ───────────────────────────────────────────────────────────
+
+SELECT ok(
+  (SELECT relrowsecurity FROM pg_class
+   WHERE relname = 'leads' AND relnamespace = 'public'::regnamespace),
+  'RLS is enabled on leads'
+);
+
+SELECT ok(
+  EXISTS (SELECT 1 FROM pg_policies
+          WHERE schemaname = 'public' AND tablename = 'leads'
+            AND policyname = 'leads_insert_public'),
+  'policy leads_insert_public exists'
+);
+
+SELECT ok(
+  EXISTS (SELECT 1 FROM pg_policies
+          WHERE schemaname = 'public' AND tablename = 'leads'
+            AND policyname = 'leads_select_owner'),
+  'policy leads_select_owner exists'
+);
+
+-- ── Privileges ───────────────────────────────────────────────────────────────
+
+SELECT ok(
+   has_table_privilege('anon', 'public.leads', 'INSERT'),
+  'anon has INSERT privilege'
+);
+
+SELECT ok(
+  NOT has_table_privilege('anon', 'public.leads', 'SELECT'),
+  'anon does not have SELECT privilege'
+);
+
+SELECT ok(
+  NOT has_table_privilege('authenticated', 'public.leads', 'SELECT'),
+  'authenticated does not have SELECT privilege'
+);
+
+-- ── Constraint enforcement ───────────────────────────────────────────────────
+
+SELECT throws_ok(
+  $$INSERT INTO leads (name, email, message) VALUES ('T', 'e@e.com', 'msg')$$,
+  '23502',
+  NULL,
+  'ip_hash NOT NULL is enforced'
+);
+
+SELECT throws_ok(
+  $$INSERT INTO leads (name, email, message, ip_hash, status)
+    VALUES ('T', 'e@e.com', 'msg', repeat('a', 64), 'invalid_status')$$,
+  '23514',
+  NULL,
+  'invalid status rejected by CHECK constraint'
+);
+
+SELECT * FROM finish();
+ROLLBACK;


### PR DESCRIPTION
## Criar schema de leads com campos mínimos e policy LGPD

  | Campo | Valor |
  |---|---|
  | **CP** | CP6 — Formulário de contato e captação de leads |
  | **Iteração** | IT1 |
  | **Issue** | Closes #85 |
  | **Chief Programmer** | @HeitorM50  |
  | **Class Owner** | @LeoFacB |

  ---

  ## O que foi implementado

  - Migration `20260524201624_create_leads.sql` criando a tabela `leads` com campos
    mínimos (LGPD): `id`, `name`, `email`, `company`, `product_interest`, `message`,
    `status`, `ip_hash` e `created_at` — sem telefone, CPF ou qualquer dado além do
    necessário para o contato comercial.
  - RLS habilitado: `INSERT` público (anon) sem autenticação; `SELECT` restrito a
    `role = 'owner'` no JWT; `UPDATE`/`DELETE` bloqueados por ausência de policy.
  - Dois índices: `created_at DESC` para listagem paginada e `ip_hash` para lookup
    de rate-limit.
  - `REVOKE SELECT ON leads FROM anon, authenticated` para ocultar a tabela do
    schema GraphQL/PostgREST.

  ---

  ## DoD — Definition of Done

  - [x] Critérios de aceite todos validados (Given/When/Then cobertos)
  - [x] Testes automatizados passando (unitários + integração onde há lógica de negócio)
  - [x] Lint sem erros (ESLint + Prettier)
  - [x] CI verde (build + testes + lint)
  - [x] Migration de banco aplicada em staging sem erros (se existir)
  - [x] Validação parcial registrada pelo cliente na issue (ou agendada para próxima validação formal)
  - [x] Documentação atualizada (README, ADR ou gh-pages) se necessário
  - [x] Sem vulnerabilidades críticas abertas no SAST/linting de segurança

  ---

  ## Checklist de revisão (para o revisor)

  - [x] Lógica de negócio correta segundo os critérios de aceitação da issue
  - [x] Sem código morto ou TODO não rastreado
  - [x] Nenhuma credencial, secret ou dado sensível exposto
  - [x] Nomes de variáveis/funções seguem convenção do projeto

  ---


  ## Evidências

<img width="766" height="469" alt="Primeira imagem" src="https://github.com/user-attachments/assets/a5bd9e93-2076-4fca-8248-c7afd6fff128" />  


---

<img width="423" height="471" alt="Segunda imagem" src="https://github.com/user-attachments/assets/46446beb-07f6-4285-999c-63892c174969" />  


---

<img width="323" height="417" alt="Terceira imagem" src="https://github.com/user-attachments/assets/3e75ea63-c2bc-475f-9ff5-58348b4d5e83" />  



  ---
  
  ## Notas para o revisor

  - A policy de INSERT com `WITH CHECK (true)` é intencional: o formulário público
    de captação de leads exige inserção anônima. O rate-limit por `ip_hash` é
    responsabilidade do backend (RNF10).
  - `(select auth.jwt())` em vez de `auth.jwt()` direto: evita re-avaliação por
    linha, conforme recomendação do linter do Supabase.
  - `REVOKE SELECT FROM anon, authenticated` é uma camada adicional além do RLS para
    remover a tabela do schema GraphQL — sem isso ela aparece como descobrível mesmo
    com policies bloqueando a leitura.