### PR TITLE
feat: implement products table with RLS and storage buckets, refactor…

### DIFF
--- a/backend/tests/database/products.test.ts
+++ b/backend/tests/database/products.test.ts
@@ -25,7 +25,7 @@ describe('products migration', () => {
       'CREATE INDEX idx_products_published_order ON public.products (published, display_order)'
     );
     expect(migrationSql).toContain('handle_products_updated_at');
-    expect(migrationSql).toContain('extensions.moddatetime()');
+    expect(migrationSql).toContain('extensions.moddatetime');
   });
 
   it('habilita RLS com as policies corretas', () => {

--- a/supabase/migrations/20260523000000_create_products_table.sql
+++ b/supabase/migrations/20260523000000_create_products_table.sql
@@ -34,7 +34,7 @@ CREATE INDEX idx_products_published_order ON public.products (published, display
 CREATE TRIGGER handle_products_updated_at
     BEFORE UPDATE ON public.products
     FOR EACH ROW
-    EXECUTE FUNCTION extensions.moddatetime();
+    EXECUTE FUNCTION extensions.moddatetime(updated_at);
 
 ALTER TABLE public.products ENABLE ROW LEVEL SECURITY;
 
@@ -73,3 +73,20 @@ ON storage.objects
 FOR INSERT
 TO authenticated
 WITH CHECK (bucket_id = 'product-images');
+
+-- RPC to reorder products
+CREATE OR REPLACE FUNCTION public.reorder_products(p_orders jsonb)
+RETURNS void
+LANGUAGE plpgsql
+SECURITY DEFINER
+AS $$
+DECLARE
+  r RECORD;
+BEGIN
+  FOR r IN SELECT * FROM jsonb_to_recordset(p_orders) AS x(id uuid, display_order int) LOOP
+    UPDATE public.products
+    SET display_order = r.display_order
+    WHERE id = r.id;
+  END LOOP;
+END;
+$$;

--- a/supabase/migrations/20260523000000_create_products_table.sql
+++ b/supabase/migrations/20260523000000_create_products_table.sql
@@ -34,7 +34,7 @@ CREATE INDEX idx_products_published_order ON public.products (published, display
 CREATE TRIGGER handle_products_updated_at
     BEFORE UPDATE ON public.products
     FOR EACH ROW
-    EXECUTE FUNCTION extensions.moddatetime(updated_at);
+    EXECUTE FUNCTION extensions.moddatetime();
 
 ALTER TABLE public.products ENABLE ROW LEVEL SECURITY;
 
@@ -73,20 +73,3 @@ ON storage.objects
 FOR INSERT
 TO authenticated
 WITH CHECK (bucket_id = 'product-images');
-
--- RPC to reorder products
-CREATE OR REPLACE FUNCTION public.reorder_products(p_orders jsonb)
-RETURNS void
-LANGUAGE plpgsql
-SECURITY DEFINER
-AS $$
-DECLARE
-  r RECORD;
-BEGIN
-  FOR r IN SELECT * FROM jsonb_to_recordset(p_orders) AS x(id uuid, display_order int) LOOP
-    UPDATE public.products
-    SET display_order = r.display_order
-    WHERE id = r.id;
-  END LOOP;
-END;
-$$;

--- a/supabase/migrations/20260529180000_profiles_rls_and_schema_fix.sql
+++ b/supabase/migrations/20260529180000_profiles_rls_and_schema_fix.sql
@@ -1,0 +1,126 @@
+-- 1. First, drop old policies to remove dependency on role/status columns before altering their types
+drop policy if exists "profiles_self_read" on public.profiles;
+drop policy if exists "owner_update_profiles" on public.profiles;
+drop policy if exists "owner_insert_profiles" on public.profiles;
+drop policy if exists "owner_delete_profiles" on public.profiles;
+drop policy if exists "profiles_owner_all" on public.profiles;
+drop policy if exists "profiles_member_read" on public.profiles;
+drop policy if exists "profiles_member_update" on public.profiles;
+
+-- 2. Alter columns in public.profiles:
+-- First, drop default constraints so we can change the type
+alter table public.profiles alter column role drop default;
+alter table public.profiles alter column status drop default;
+
+-- Change role column type to text
+alter table public.profiles 
+  alter column role set data type text using role::text;
+
+-- Add check constraint for role
+alter table public.profiles 
+  add constraint profiles_role_check check (role in ('owner', 'member'));
+
+-- Set default for role
+alter table public.profiles alter column role set default 'member';
+
+-- Change status column type to text
+alter table public.profiles 
+  alter column status set data type text using status::text;
+
+-- Add check constraint for status
+alter table public.profiles 
+  add constraint profiles_status_check check (status in ('active', 'inactive'));
+
+-- Set default for status
+alter table public.profiles alter column status set default 'active';
+
+-- Drop the old enum types
+drop type if exists role_type;
+drop type if exists status_type;
+
+-- 3. Make sure name and email are NOT NULL:
+-- Update existing null names to a default value first to prevent constraint violations
+update public.profiles set name = 'Novo Membro' where name is null;
+alter table public.profiles alter column name set not null;
+
+-- Make sure email is not null (should already be populated, but enforce it)
+update public.profiles set email = 'membro_' || id || '@crianex.local' where email is null;
+alter table public.profiles alter column email set not null;
+
+
+-- 4. Update trigger function for handle_new_user:
+create or replace function public.handle_new_user()
+returns trigger
+language plpgsql
+security definer
+as $$
+begin
+    insert into public.profiles (
+        id,
+        name,
+        email,
+        role,
+        status
+    )
+    values (
+        new.id,
+        coalesce(new.raw_user_meta_data->>'name', split_part(new.email, '@', 1), 'Membro'),
+        new.email,
+        'member',
+        'active'
+    );
+    return new;
+end;
+$$;
+
+
+-- 5. Create is_owner function for RLS policy to bypass recursion
+create or replace function public.is_owner(user_id uuid)
+returns boolean
+language sql
+security definer
+set search_path = public
+stable
+as $$
+  select exists (
+    select 1
+    from public.profiles
+    where id = user_id
+    and role = 'owner'
+  );
+$$;
+
+
+-- 6. Create RLS policies:
+-- Policy for owner: full CRUD access
+create policy "profiles_owner_all"
+on public.profiles
+for all
+to authenticated
+using (
+    public.is_owner(auth.uid())
+)
+with check (
+    public.is_owner(auth.uid())
+);
+
+-- Policy for member: read self only
+create policy "profiles_member_read"
+on public.profiles
+for select
+to authenticated
+using (
+    auth.uid() = id
+);
+
+-- Policy for member: update self only
+create policy "profiles_member_update"
+on public.profiles
+for update
+to authenticated
+using (
+    auth.uid() = id
+)
+with check (
+    auth.uid() = id
+);

--- a/supabase/migrations/20260529180000_profiles_rls_and_schema_fix.sql
+++ b/supabase/migrations/20260529180000_profiles_rls_and_schema_fix.sql
@@ -22,7 +22,7 @@ alter table public.profiles
   alter column role set data type text using role::text;
 
 alter table public.profiles
-  add constraint if not exists profiles_role_check check (role in ('owner', 'member'));
+  add constraint profiles_role_check check (role in ('owner', 'member'));
 
 alter table public.profiles alter column role set default 'member';
 
@@ -30,7 +30,7 @@ alter table public.profiles
   alter column status set data type text using status::text;
 
 alter table public.profiles
-  add constraint if not exists profiles_status_check check (status in ('active', 'inactive'));
+  add constraint profiles_status_check check (status in ('active', 'inactive'));
 
 alter table public.profiles alter column status set default 'active';
 

--- a/supabase/migrations/20260529180000_profiles_rls_and_schema_fix.sql
+++ b/supabase/migrations/20260529180000_profiles_rls_and_schema_fix.sql
@@ -1,4 +1,4 @@
--- 1. First, drop old policies to remove dependency on role/status columns before altering their types
+-- 1. Drop old policies to remove dependency on role/status columns before altering their types
 drop policy if exists "profiles_self_read" on public.profiles;
 drop policy if exists "owner_update_profiles" on public.profiles;
 drop policy if exists "owner_insert_profiles" on public.profiles;
@@ -7,48 +7,50 @@ drop policy if exists "profiles_owner_all" on public.profiles;
 drop policy if exists "profiles_member_read" on public.profiles;
 drop policy if exists "profiles_member_update" on public.profiles;
 
+-- Fix moddatetime trigger (was created without column argument in migration 20260523000000)
+drop trigger if exists handle_products_updated_at on public.products;
+create trigger handle_products_updated_at
+    before update on public.products
+    for each row
+    execute function extensions.moddatetime(updated_at);
+
 -- 2. Alter columns in public.profiles:
--- First, drop default constraints so we can change the type
 alter table public.profiles alter column role drop default;
 alter table public.profiles alter column status drop default;
 
--- Change role column type to text
-alter table public.profiles 
+alter table public.profiles
   alter column role set data type text using role::text;
 
--- Add check constraint for role
-alter table public.profiles 
-  add constraint profiles_role_check check (role in ('owner', 'member'));
+alter table public.profiles
+  add constraint if not exists profiles_role_check check (role in ('owner', 'member'));
 
--- Set default for role
 alter table public.profiles alter column role set default 'member';
 
--- Change status column type to text
-alter table public.profiles 
+alter table public.profiles
   alter column status set data type text using status::text;
 
--- Add check constraint for status
-alter table public.profiles 
-  add constraint profiles_status_check check (status in ('active', 'inactive'));
+alter table public.profiles
+  add constraint if not exists profiles_status_check check (status in ('active', 'inactive'));
 
--- Set default for status
 alter table public.profiles alter column status set default 'active';
 
--- Drop the old enum types
 drop type if exists role_type;
 drop type if exists status_type;
 
--- 3. Make sure name and email are NOT NULL:
--- Update existing null names to a default value first to prevent constraint violations
+-- 3. Enforce NOT NULL on name and email
 update public.profiles set name = 'Novo Membro' where name is null;
 alter table public.profiles alter column name set not null;
 
--- Make sure email is not null (should already be populated, but enforce it)
-update public.profiles set email = 'membro_' || id || '@crianex.local' where email is null;
+do $$
+begin
+  if exists (select 1 from public.profiles where email is null) then
+    raise exception 'profiles com email NULL encontrados — corrija manualmente antes de aplicar esta migration';
+  end if;
+end;
+$$;
 alter table public.profiles alter column email set not null;
 
-
--- 4. Update trigger function for handle_new_user:
+-- 4. Update trigger function for handle_new_user
 create or replace function public.handle_new_user()
 returns trigger
 language plpgsql
@@ -73,8 +75,7 @@ begin
 end;
 $$;
 
-
--- 5. Create is_owner function for RLS policy to bypass recursion
+-- 5. Create is_owner function (SECURITY DEFINER + search_path to avoid RLS recursion)
 create or replace function public.is_owner(user_id uuid)
 returns boolean
 language sql
@@ -90,9 +91,29 @@ as $$
   );
 $$;
 
+-- 6. RPC to reorder products (owner only)
+create or replace function public.reorder_products(p_orders jsonb)
+returns void
+language plpgsql
+security definer
+set search_path = public
+as $$
+declare
+  r record;
+begin
+  if not public.is_owner(auth.uid()) then
+    raise exception 'permission denied: only owners can reorder products';
+  end if;
 
--- 6. Create RLS policies:
--- Policy for owner: full CRUD access
+  for r in select * from jsonb_to_recordset(p_orders) as x(id uuid, display_order int) loop
+    update public.products
+    set display_order = r.display_order
+    where id = r.id;
+  end loop;
+end;
+$$;
+
+-- 7. Create RLS policies
 create policy "profiles_owner_all"
 on public.profiles
 for all
@@ -104,7 +125,6 @@ with check (
     public.is_owner(auth.uid())
 );
 
--- Policy for member: read self only
 create policy "profiles_member_read"
 on public.profiles
 for select
@@ -113,7 +133,6 @@ using (
     auth.uid() = id
 );
 
--- Policy for member: update self only
 create policy "profiles_member_update"
 on public.profiles
 for update


### PR DESCRIPTION
## Feature entregue

> Formato FDD: **Criar schema de profiles com políticas de RLS e triggers para gerenciamento de membros**

| Campo | Valor |
|---|---|
| **CP** | CP8 — Painel de gerenciamento de produtos SaaS (admin) |
| **Iteração** | IT1 |
| **Issue** | Closes #74 |
| **Chief Programmer** | @HeitorM50  |

---

## O que foi implementado

- Criação da migração [20260529180000_profiles_rls_and_schema_fix.sql](file:///c:/Users/Best%20Option%20Notebook/OneDrive/Documents/REQ-2026.1-T02-Crianex-/supabase/migrations/20260529180000_profiles_rls_and_schema_fix.sql) para estruturar a tabela `profiles` e suas políticas de controle de acesso (RLS).
- Conversão das colunas `role` e `status` de enums PostgreSQL para o tipo `text` com restrições `CHECK` (`in ('owner', 'member')` e `in ('active', 'inactive')`).
- Aplicação de restrição `NOT NULL` nos campos `name` e `email` da tabela `profiles`.
- Atualização da função/gatilho de banco `handle_new_user()` para autocompletar o campo `name` caso não esteja presente nos metadados do usuário cadastrado, prevenindo erros de validação no login.
- Implementação de políticas RLS na tabela `profiles` diferenciando privilégios:
  * `owner` possui acesso total (CRUD).
  * `member` possui acesso de leitura (`SELECT`) e atualização (`UPDATE`) restrito ao seu próprio registro (`auth.uid() = id`).
  * Acessos não autenticados retornam 0 linhas.
- Criação da função de banco `public.is_owner(uuid)` com `SECURITY DEFINER` e `SET search_path = public` para evitar recursão infinita nas políticas de RLS.
- Correção de bugs de triggers e RPCs no banco de dados de produtos ([20260523000000_create_products_table.sql](file:///c:/Users/Best%20Option%20Notebook/OneDrive/Documents/REQ-2026.1-T02-Crianex-/supabase/migrations/20260523000000_create_products_table.sql)):
  * Passagem correta da coluna `updated_at` no trigger `handle_products_updated_at` chamando `moddatetime`.
  * Criação da RPC `reorder_products(jsonb)` que estava ausente, permitindo o correto funcionamento do CRUD de produtos e reordenação.
- Correção de asserções em [products.test.ts](file:///c:/Users/Best%20Option%20Notebook/OneDrive/Documents/REQ-2026.1-T02-Crianex-/backend/tests/database/products.test.ts) para acomodar a sintaxe correta do trigger.

---

## DoD — Definition of Done

- [x] Critérios de aceite todos validados (Given/When/Then cobertos)
- [x] Testes automatizados passando (unitários + integração onde há lógica de negócio)
- [x] Lint sem erros (ESLint + Prettier)
- [x] CI verde (build + testes + lint)
- [x] Migration de banco aplicada em staging sem erros (se existir)
- [x] Validação parcial registrada pelo cliente na issue (ou agendada para próxima validação formal)
- [x] Documentação atualizada (README, ADR ou gh-pages) se necessário
- [x] Sem vulnerabilidades críticas abertas no SAST/linting de segurança

---

## Checklist de revisão (para o revisor)

- [x] Lógica de negócio correta segundo os critérios de aceitação da issue
- [x] Sem código morto ou TODO não rastreado
- [x] Nenhuma credencial, secret ou dado sensível exposto
- [x] Nomes de variáveis/funções seguem convenção do projeto

---

## Evidências

1. **Testes do Backend (Green Suite com 46 testes)**:
<img width="932" height="377" alt="image" src="https://github.com/user-attachments/assets/13aa46a6-8c79-477d-9055-cd7fa6299029" />
<img width="935" height="366" alt="image" src="https://github.com/user-attachments/assets/e40ee4ca-a2a6-4328-9ca6-83c34bd67178" />


   ```bash
   RUN  v3.2.4 C:/Users/Best Option Notebook/OneDrive/Documents/REQ-2026.1-T02-Crianex-/backend

   ✓ tests/database/products.test.ts (4 tests) 10ms
   ✓ src/lib/health.test.ts (1 test) 12ms
   ✓ src/auth/auth.mfa.test.ts (2 tests) 16ms
   ✓ src/auth/auth.service.test.ts (4 tests) 12ms
   ✓ src/leads/leads.test.ts (18 tests) 28ms
   ✓ src/lib/leads.test.ts (10 tests) 1142ms
   ✓ src/routes/saasProductsCRUD.test.ts (7 tests) 502ms

   Test Files  7 passed (7)
        Tests  46 passed (46)
     Duration  3.98s
RUN  v3.2.4 C:/Users/Best Option Notebook/OneDrive/Documents/REQ-2026.1-T02-Crianex-/frontend

✓ src/lib/utils/utils.test.ts (1 test) 6ms
✓ src/routes/(vitrine)/contato/contact.test.ts (16 tests) 16ms

Test Files  2 passed (2)
     Tests  17 passed (17)
  Duration  1.25s


