### PR TITLE
Feat/issue#94 criar schema de artigos e categorias faq com rls e categorias vinculadas a produtos

### DIFF
--- a/supabase/migrations/20260530000100_create_faq_tables.sql
+++ b/supabase/migrations/20260530000100_create_faq_tables.sql
@@ -39,8 +39,8 @@ create table public.faq_articles (
     category_id uuid not null references public.faq_categories(id) on delete cascade,
     published boolean default false not null,
     published_at timestamp with time zone,
-    helpful_count integer default 0 not null,
-    not_helpful_count integer default 0 not null,
+    helpful_count integer default 0 not null check (helpful_count >= 0),
+    not_helpful_count integer default 0 not null check (not_helpful_count >= 0),
     created_at timestamp with time zone default timezone('utc'::text, now()) not null,
     updated_at timestamp with time zone default timezone('utc'::text, now()) not null,
     slug text not null unique
@@ -50,11 +50,23 @@ create or replace function public.set_faq_category_slug()
 returns trigger
 language plpgsql
 as $$
+declare
+    base_slug text;
+    candidate  text;
+    counter    int := 1;
 begin
     if coalesce(new.slug, '') = '' then
-        new.slug := public.slugify(new.label_pt);
+        base_slug := public.slugify(new.label_pt);
+        candidate := base_slug;
+        while exists (
+            select 1 from public.faq_categories
+            where slug = candidate and id <> new.id
+        ) loop
+            candidate := base_slug || '-' || counter;
+            counter := counter + 1;
+        end loop;
+        new.slug := candidate;
     end if;
-
     return new;
 end;
 $$;
@@ -63,11 +75,37 @@ create or replace function public.set_faq_article_slug()
 returns trigger
 language plpgsql
 as $$
+declare
+    base_slug text;
+    candidate  text;
+    counter    int := 1;
 begin
     if coalesce(new.slug, '') = '' then
-        new.slug := public.slugify(new.title_pt);
+        base_slug := public.slugify(new.title_pt);
+        candidate := base_slug;
+        while exists (
+            select 1 from public.faq_articles
+            where slug = candidate and id <> new.id
+        ) loop
+            candidate := base_slug || '-' || counter;
+            counter := counter + 1;
+        end loop;
+        new.slug := candidate;
     end if;
+    return new;
+end;
+$$;
 
+create or replace function public.set_faq_article_published_at()
+returns trigger
+language plpgsql
+as $$
+begin
+    if new.published = true and (old is null or old.published = false) then
+        new.published_at := now();
+    elsif new.published = false then
+        new.published_at := null;
+    end if;
     return new;
 end;
 $$;
@@ -83,6 +121,12 @@ before insert or update of title_pt, slug
 on public.faq_articles
 for each row
 execute function public.set_faq_article_slug();
+
+create trigger handle_faq_articles_published_at
+before insert or update of published
+on public.faq_articles
+for each row
+execute function public.set_faq_article_published_at();
 
 create trigger handle_faq_articles_updated_at
 before update on public.faq_articles
@@ -125,5 +169,8 @@ on public.faq_categories(display_order);
 create index idx_faq_articles_category_id
 on public.faq_articles(category_id);
 
+create index idx_faq_articles_category_published
+on public.faq_articles(category_id, published);
+
 create index idx_faq_articles_published
-on public.faq_articles(published);
+on public.faq_articles(published) where published = true;

--- a/supabase/migrations/20260530000100_create_faq_tables.sql
+++ b/supabase/migrations/20260530000100_create_faq_tables.sql
@@ -1,0 +1,129 @@
+create schema if not exists extensions;
+create extension if not exists moddatetime with schema extensions;
+create extension if not exists unaccent with schema extensions;
+
+create or replace function public.slugify(input text)
+returns text
+language sql
+immutable
+as $$
+    select regexp_replace(
+        regexp_replace(
+            lower(extensions.unaccent(trim(input))),
+            '[^a-z0-9]+',
+            '-',
+            'g'
+        ),
+        '(^-|-$)',
+        '',
+        'g'
+    );
+$$;
+
+create table public.faq_categories (
+    id uuid default gen_random_uuid() primary key,
+    label_pt text not null,
+    label_en text not null,
+    product_id uuid references public.products(id) on delete set null,
+    display_order integer default 0 not null,
+    slug text not null unique,
+    created_at timestamp with time zone default timezone('utc'::text, now()) not null
+);
+
+create table public.faq_articles (
+    id uuid default gen_random_uuid() primary key,
+    title_pt text not null,
+    title_en text not null,
+    body_pt text not null,
+    body_en text not null,
+    category_id uuid not null references public.faq_categories(id) on delete cascade,
+    published boolean default false not null,
+    published_at timestamp with time zone,
+    helpful_count integer default 0 not null,
+    not_helpful_count integer default 0 not null,
+    created_at timestamp with time zone default timezone('utc'::text, now()) not null,
+    updated_at timestamp with time zone default timezone('utc'::text, now()) not null,
+    slug text not null unique
+);
+
+create or replace function public.set_faq_category_slug()
+returns trigger
+language plpgsql
+as $$
+begin
+    if coalesce(new.slug, '') = '' then
+        new.slug := public.slugify(new.label_pt);
+    end if;
+
+    return new;
+end;
+$$;
+
+create or replace function public.set_faq_article_slug()
+returns trigger
+language plpgsql
+as $$
+begin
+    if coalesce(new.slug, '') = '' then
+        new.slug := public.slugify(new.title_pt);
+    end if;
+
+    return new;
+end;
+$$;
+
+create trigger handle_faq_categories_slug
+before insert or update of label_pt, slug
+on public.faq_categories
+for each row
+execute function public.set_faq_category_slug();
+
+create trigger handle_faq_articles_slug
+before insert or update of title_pt, slug
+on public.faq_articles
+for each row
+execute function public.set_faq_article_slug();
+
+create trigger handle_faq_articles_updated_at
+before update on public.faq_articles
+for each row
+execute function extensions.moddatetime(updated_at);
+
+alter table public.faq_categories enable row level security;
+alter table public.faq_articles enable row level security;
+
+create policy "Permitir leitura pública de categorias FAQ"
+on public.faq_categories
+for select
+using (true);
+
+create policy "Permitir leitura pública de artigos FAQ publicados"
+on public.faq_articles
+for select
+using (published = true);
+
+create policy "Permitir gerenciamento de categorias FAQ para owners"
+on public.faq_categories
+for all
+to authenticated
+using (public.is_owner(auth.uid()))
+with check (public.is_owner(auth.uid()));
+
+create policy "Permitir gerenciamento de artigos FAQ para owners"
+on public.faq_articles
+for all
+to authenticated
+using (public.is_owner(auth.uid()))
+with check (public.is_owner(auth.uid()));
+
+create index idx_faq_categories_product_id
+on public.faq_categories(product_id);
+
+create index idx_faq_categories_display_order
+on public.faq_categories(display_order);
+
+create index idx_faq_articles_category_id
+on public.faq_articles(category_id);
+
+create index idx_faq_articles_published
+on public.faq_articles(published);


### PR DESCRIPTION
## Descrição

Implementa o schema de FAQ para a base de conhecimento, incluindo:

* Criação das tabelas `faq_categories` e `faq_articles`;
* Suporte bilíngue (PT/EN);
* Relacionamento opcional entre categorias e produtos;
* Geração automática de slugs;
* Configuração de Row Level Security (RLS);
* Políticas de acesso público para categorias e artigos publicados;
* Políticas de gerenciamento para owners;
* Trigger de atualização automática de `updated_at` em artigos;
* Índices para otimização de consultas.

Closes #94
