### PR TITLE
feat(about): implement About page with SSR and i18n support

### DIFF
--- a/frontend/src/lib/i18n/en/about.json
+++ b/frontend/src/lib/i18n/en/about.json
@@ -1,0 +1,44 @@
+{
+  "eyebrow": "About Crianex",
+  "h1": "A B2B software house based in São Paulo since 2019.",
+  "lede": "We started as a consultancy. In 2021 we stopped selling hours and started selling product. We now run six vertical SaaS on a shared Kubernetes platform.",
+  "missionEyebrow": "Mission, vision, values",
+  "missionTitle": "What keeps the team aligned.",
+  "missionDesc": "Three principles chosen not for rhetoric, but because they change real decisions — from hiring to releases.",
+  "values": [
+    {
+      "n": "01",
+      "title": "Engineering first",
+      "body": "We invest in foundation before features. A stack chosen to last a decade, not a quarter."
+    },
+    {
+      "n": "02",
+      "title": "Product, not project",
+      "body": "We build reusable platforms. Every customer inherits every prior customer's learnings."
+    },
+    {
+      "n": "03",
+      "title": "Decisions with data",
+      "body": "Instrumentation from day zero. Every release has a measurable hypothesis and a rollback cutoff."
+    }
+  ],
+  "numbersEyebrow": "By the numbers",
+  "numbersTitle": "Seven years. Six products. One lean team.",
+  "numbersDesc": "We grow through product quality, not headcount. Shared infrastructure gives us unusual leverage.",
+  "stats": [
+    { "value": "6", "label": "SaaS products in production" },
+    { "value": "184", "label": "active B2B customers" },
+    { "value": "28", "label": "engineers & designers" },
+    { "value": "2019", "label": "founded in São Paulo" }
+  ],
+  "cta": {
+    "title": "Work with us.",
+    "body": "Either as a customer or an engineer. We're open to both kinds of conversation.",
+    "emailLabel": "comercial@crianex.com.br",
+    "linkedinLabel": "LinkedIn"
+  },
+  "seo": {
+    "title": "About Crianex | Crianex Hub",
+    "ogTitle": "About Crianex | Crianex Hub"
+  }
+}

--- a/frontend/src/lib/i18n/pt/about.json
+++ b/frontend/src/lib/i18n/pt/about.json
@@ -1,0 +1,44 @@
+{
+  "eyebrow": "Sobre a Crianex",
+  "h1": "Software house B2B baseada em São Paulo desde 2019.",
+  "lede": "Começamos como consultoria. Em 2021 paramos de vender hora-homem e passamos a vender produto. Hoje operamos seis SaaS verticais sobre uma plataforma comum em Kubernetes.",
+  "missionEyebrow": "Missão, visão, valores",
+  "missionTitle": "O que mantém o time alinhado.",
+  "missionDesc": "Três princípios escolhidos não pela retórica, mas porque mudam decisões reais — de contratação a release.",
+  "values": [
+    {
+      "n": "01",
+      "title": "Engenharia primeiro",
+      "body": "Investimos em fundação técnica antes de feature. Stack escolhida para durar uma década, não um trimestre."
+    },
+    {
+      "n": "02",
+      "title": "Produto, não projeto",
+      "body": "Construímos plataformas reutilizáveis. Cada cliente herda o aprendizado de todos os anteriores."
+    },
+    {
+      "n": "03",
+      "title": "Decisão com dado",
+      "body": "Instrumentação desde o dia zero. Cada release tem hipótese mensurável e cutoff de rollback."
+    }
+  ],
+  "numbersEyebrow": "Em números",
+  "numbersTitle": "Sete anos. Seis produtos. Um time enxuto.",
+  "numbersDesc": "Crescemos pela qualidade do produto, não pelo tamanho do time. Estrutura compartilhada permite alavancagem incomum.",
+  "stats": [
+    { "value": "6", "label": "produtos SaaS em produção" },
+    { "value": "184", "label": "clientes B2B ativos" },
+    { "value": "28", "label": "engenheiros & designers" },
+    { "value": "2019", "label": "fundada em São Paulo" }
+  ],
+  "cta": {
+    "title": "Trabalhar com a gente.",
+    "body": "Tanto como cliente quanto como engenheiro. Estamos abertos para conversa nas duas frentes.",
+    "emailLabel": "comercial@crianex.com.br",
+    "linkedinLabel": "LinkedIn"
+  },
+  "seo": {
+    "title": "Sobre a Crianex | Crianex Hub",
+    "ogTitle": "Sobre a Crianex | Crianex Hub"
+  }
+}

--- a/frontend/src/routes/(vitrine)/sobre/+page.server.ts
+++ b/frontend/src/routes/(vitrine)/sobre/+page.server.ts
@@ -1,0 +1,12 @@
+import type { ServerLoad as PageServerLoad } from '@sveltejs/kit';
+import { aboutContent } from './about';
+
+export const prerender = false;
+
+export const load: PageServerLoad = ({ locals }) => {
+  const lang = locals.lang === 'en' ? 'en' : 'pt';
+  return {
+    aboutContent,
+    initialLang: lang,
+  };
+};

--- a/frontend/src/routes/(vitrine)/sobre/+page.svelte
+++ b/frontend/src/routes/(vitrine)/sobre/+page.svelte
@@ -1,11 +1,304 @@
 <script lang="ts">
-  // Página institucional About — issue #92
+  import { lang } from '$lib/stores/lang';
+  import type { PageData } from './$types';
+
+  export let data: PageData;
+
+  $: content = data.aboutContent[$lang] ?? data.aboutContent[data.initialLang];
 </script>
 
 <svelte:head>
-  <title>Sobre — Crianex</title>
+  <title>{content.seo.title}</title>
+  <meta name="description" content={content.lede} />
+  <meta property="og:title" content={content.seo.ogTitle} />
+  <meta property="og:description" content={content.lede} />
+  <meta property="og:type" content="website" />
 </svelte:head>
 
-<section>
-  <p>Em desenvolvimento</p>
-</section>
+<article class="about" data-testid="about-page">
+  <section class="about-hero">
+    <div class="eyebrow">
+      <span class="dot"></span>
+      {content.eyebrow}
+    </div>
+    <h1>{content.h1}</h1>
+    <p class="lede">{content.lede}</p>
+  </section>
+
+  <section class="section mission">
+    <div class="section-head">
+      <div>
+        <div class="eyebrow">
+          <span class="dot pink"></span>
+          {content.missionEyebrow}
+        </div>
+        <h2>{content.missionTitle}</h2>
+      </div>
+      <p class="desc">{content.missionDesc}</p>
+    </div>
+    <div class="values-grid">
+      {#each content.values as v (v.n)}
+        <div class="value-card">
+          <span class="n">{v.n}</span>
+          <h4>{v.title}</h4>
+          <p>{v.body}</p>
+        </div>
+      {/each}
+    </div>
+  </section>
+
+  <section class="section numbers">
+    <div class="section-head">
+      <div>
+        <div class="eyebrow">
+          <span class="dot green"></span>
+          {content.numbersEyebrow}
+        </div>
+        <h2>{content.numbersTitle}</h2>
+      </div>
+      <p class="desc">{content.numbersDesc}</p>
+    </div>
+    <div class="stats-grid">
+      {#each content.stats as s (s.label)}
+        <div class="stat">
+          <span class="label">{s.label}</span>
+          <span class="value">{s.value}</span>
+        </div>
+      {/each}
+    </div>
+  </section>
+
+  <section class="section">
+    <div class="cta-banner">
+      <div>
+        <h3>{content.cta.title}</h3>
+        <p>{content.cta.body}</p>
+      </div>
+      <div class="cta-actions">
+        <a class="btn primary" href="mailto:comercial@crianex.com.br">
+          {content.cta.emailLabel}
+        </a>
+        <a
+          class="btn ghost"
+          href="https://linkedin.com/company/crianex"
+          target="_blank"
+          rel="noopener noreferrer"
+        >
+          {content.cta.linkedinLabel}
+        </a>
+      </div>
+    </div>
+  </section>
+</article>
+
+<style>
+  .about {
+    --r-lg: 18px;
+    --line: #e8e6e2;
+    --bg-soft: #f5f3ef;
+    --text-muted: #6b6862;
+    --text-faint: #9a968e;
+
+    max-width: 1200px;
+    margin: 0 auto;
+    padding: 80px 40px;
+    color: #060606;
+  }
+
+  .eyebrow {
+    display: inline-flex;
+    align-items: center;
+    gap: 8px;
+    font-size: 12px;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+    color: var(--text-muted);
+    margin-bottom: 14px;
+  }
+  .dot {
+    width: 6px;
+    height: 6px;
+    border-radius: 999px;
+    background: var(--venom, #060606);
+  }
+  .dot.pink {
+    background: var(--pink, #e71f84);
+  }
+  .dot.green {
+    background: var(--green, #66df7a);
+  }
+
+  .about-hero {
+    padding: 32px 0 64px;
+    border-bottom: 1px solid var(--line);
+  }
+  .about-hero h1 {
+    font-size: clamp(40px, 6vw, 72px);
+    line-height: 1.05;
+    letter-spacing: -0.02em;
+    margin: 0 0 24px;
+    max-width: 18ch;
+  }
+  .lede {
+    font-size: 18px;
+    line-height: 1.6;
+    color: var(--text-muted);
+    max-width: 60ch;
+  }
+
+  .section {
+    padding: 80px 0;
+    border-bottom: 1px solid var(--line);
+  }
+  .section:last-child {
+    border-bottom: none;
+  }
+  .section-head {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 48px;
+    margin-bottom: 48px;
+  }
+  .section-head h2 {
+    font-size: clamp(28px, 3.5vw, 40px);
+    line-height: 1.1;
+    letter-spacing: -0.01em;
+    margin: 0;
+    max-width: 18ch;
+  }
+  .desc {
+    font-size: 15px;
+    line-height: 1.6;
+    color: var(--text-muted);
+    max-width: 44ch;
+    margin: 0;
+  }
+
+  .values-grid {
+    display: grid;
+    grid-template-columns: repeat(3, 1fr);
+    gap: 24px;
+  }
+  .value-card {
+    border: 1px solid var(--line);
+    border-radius: var(--r-lg);
+    padding: 28px;
+    background: #ffffff;
+  }
+  .value-card .n {
+    font-family: var(--font-mono, monospace);
+    font-size: 11px;
+    color: var(--text-faint);
+    letter-spacing: 0.08em;
+  }
+  .value-card h4 {
+    font-size: 20px;
+    margin: 16px 0 12px;
+    letter-spacing: -0.01em;
+  }
+  .value-card p {
+    font-size: 14px;
+    line-height: 1.6;
+    color: var(--text-muted);
+    margin: 0;
+  }
+
+  .numbers {
+    background: var(--bg-soft);
+    margin: 0 -40px;
+    padding-left: 40px;
+    padding-right: 40px;
+  }
+  .stats-grid {
+    display: grid;
+    grid-template-columns: repeat(2, 1fr);
+    gap: 32px;
+  }
+  .stat {
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
+    padding: 24px 0;
+    border-top: 1px solid var(--line);
+  }
+  .stat .label {
+    font-family: var(--font-mono, monospace);
+    font-size: 11px;
+    color: var(--text-faint);
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+  }
+  .stat .value {
+    font-size: clamp(40px, 5vw, 64px);
+    letter-spacing: -0.02em;
+    line-height: 1;
+  }
+
+  .cta-banner {
+    display: grid;
+    grid-template-columns: 1fr auto;
+    align-items: center;
+    gap: 32px;
+    padding: 40px;
+    border-radius: var(--r-lg);
+    border: 1px solid var(--line);
+    background: #ffffff;
+  }
+  .cta-banner h3 {
+    font-size: 24px;
+    margin: 0;
+    letter-spacing: -0.01em;
+  }
+  .cta-banner p {
+    color: var(--text-muted);
+    margin: 14px 0 0;
+    font-size: 14px;
+    max-width: 44ch;
+  }
+  .cta-actions {
+    display: flex;
+    gap: 12px;
+    flex-wrap: wrap;
+  }
+  .btn {
+    display: inline-flex;
+    align-items: center;
+    gap: 8px;
+    padding: 10px 16px;
+    border-radius: 999px;
+    border: 1px solid var(--line);
+    font-size: 14px;
+    text-decoration: none;
+    color: inherit;
+    background: #ffffff;
+  }
+  .btn.primary {
+    background: #060606;
+    color: #ffffff;
+    border-color: #060606;
+  }
+  .btn.ghost {
+    background: transparent;
+  }
+
+  @media (max-width: 768px) {
+    .about {
+      padding: 48px 20px;
+    }
+    .section-head,
+    .values-grid,
+    .stats-grid {
+      grid-template-columns: 1fr;
+      gap: 24px;
+    }
+    .numbers {
+      margin: 0 -20px;
+      padding-left: 20px;
+      padding-right: 20px;
+    }
+    .cta-banner {
+      grid-template-columns: 1fr;
+      padding: 28px;
+    }
+  }
+</style>

--- a/frontend/src/routes/(vitrine)/sobre/about.test.ts
+++ b/frontend/src/routes/(vitrine)/sobre/about.test.ts
@@ -1,0 +1,60 @@
+import { describe, it, expect } from 'vitest';
+import { aboutContent, REQUIRED_KEYS } from './about';
+
+describe('about i18n content', () => {
+  it('exposes both pt and en locales', () => {
+    expect(aboutContent.pt).toBeTruthy();
+    expect(aboutContent.en).toBeTruthy();
+  });
+
+  for (const locale of ['pt', 'en'] as const) {
+    describe(`${locale} locale`, () => {
+      const c = aboutContent[locale];
+
+      it('has all required top-level keys', () => {
+        for (const key of REQUIRED_KEYS) {
+          expect(c, `missing ${key}`).toHaveProperty(key);
+        }
+      });
+
+      it('has exactly 3 values, each with n/title/body', () => {
+        expect(c.values).toHaveLength(3);
+        for (const v of c.values) {
+          expect(v.n).toBeTruthy();
+          expect(v.title).toBeTruthy();
+          expect(v.body).toBeTruthy();
+        }
+      });
+
+      it('has exactly 4 stats, each with label/value', () => {
+        expect(c.stats).toHaveLength(4);
+        for (const s of c.stats) {
+          expect(s.label).toBeTruthy();
+          expect(s.value).toBeTruthy();
+        }
+      });
+
+      it('has hero copy (eyebrow, h1, lede)', () => {
+        expect(c.eyebrow).toBeTruthy();
+        expect(c.h1).toBeTruthy();
+        expect(c.lede).toBeTruthy();
+      });
+
+      it('has cta block with title, body and labels', () => {
+        expect(c.cta.title).toBeTruthy();
+        expect(c.cta.body).toBeTruthy();
+        expect(c.cta.emailLabel).toBeTruthy();
+        expect(c.cta.linkedinLabel).toBeTruthy();
+      });
+
+      it('has SEO title following "Sobre/About a Crianex | Crianex Hub" pattern', () => {
+        expect(c.seo.title).toMatch(/Crianex Hub/);
+        expect(c.seo.ogTitle).toMatch(/Crianex Hub/);
+      });
+    });
+  }
+
+  it('pt and en have distinct copy for the hero h1', () => {
+    expect(aboutContent.pt.h1).not.toBe(aboutContent.en.h1);
+  });
+});

--- a/frontend/src/routes/(vitrine)/sobre/about.ts
+++ b/frontend/src/routes/(vitrine)/sobre/about.ts
@@ -1,0 +1,42 @@
+import ptAbout from '../../../lib/i18n/pt/about.json';
+import enAbout from '../../../lib/i18n/en/about.json';
+
+export type AboutValue = { n: string; title: string; body: string };
+export type AboutStat = { value: string; label: string };
+
+export type AboutContent = {
+  eyebrow: string;
+  h1: string;
+  lede: string;
+  missionEyebrow: string;
+  missionTitle: string;
+  missionDesc: string;
+  values: AboutValue[];
+  numbersEyebrow: string;
+  numbersTitle: string;
+  numbersDesc: string;
+  stats: AboutStat[];
+  cta: {
+    title: string;
+    body: string;
+    emailLabel: string;
+    linkedinLabel: string;
+  };
+  seo: { title: string; ogTitle: string };
+};
+
+export const aboutContent: Record<'pt' | 'en', AboutContent> = {
+  pt: ptAbout as AboutContent,
+  en: enAbout as AboutContent,
+};
+
+export const REQUIRED_KEYS = [
+  'eyebrow',
+  'h1',
+  'lede',
+  'missionEyebrow',
+  'missionTitle',
+  'values',
+  'stats',
+  'cta',
+] as const;


### PR DESCRIPTION
## Feature entregue

Construir página Sobre da vitrine com SSR e i18n estático

| Campo | Valor |
|---|---|
| **CP** | CP4 — Plataforma Pública de Apresentação da Empresa |
| **Iteração** | IT1 |
| **Issue** | Closes #92 |
| **Class Owner** | @LeoFacB |

---

## O que foi implementado

- Estrutura i18n em `frontend/src/lib/i18n/pt/about.json` e `en/about.json` cobrindo todas as chaves exigidas (`eyebrow`, `h1`, `lede`, `missionEyebrow`, `missionTitle`, `values[3]`, `stats[4]`, `cta`) + `seo.title`/`ogTitle` para Open Graph.
- Rota `/sobre` com SSR real via `+page.server.ts` que lê `locals.lang` (cookie `crianex_lang`) e devolve os dois locales — HTML inicial chega completo, sem depender de JS no cliente.
- Layout do protótipo fielmente reproduzido: hero → missão (3 value-cards) → números (`bg-soft`, grid 2 colunas com 4 stats) → CTA banner, com toggle PT/EN reativo via store `$lang` (sem reload).
- Rota pública: fica em `(vitrine)`, fora do guard de `/admin/*` em `hooks.server.ts` — visitante anônimo carrega sem interceptação (RNF20).
- Smoke test `about.test.ts` valida shape do i18n, cardinalidade (`values=3`, `stats=4`), divergência PT≠EN e padrão SEO.

---

## DoD — Definition of Done

- [x] Critérios de aceite todos validados (Given/When/Then cobertos)
- [x] Testes automatizados passando (14/14 em `about.test.ts`)
- [x] Lint sem erros (ESLint + Prettier — `npm run lint` clean nos arquivos tocados)
- [x] CI verde (build + testes + lint — `npm run build --workspace=frontend` ok)
- [x] Migration de banco aplicada em staging sem erros (se existir) — N/A, feature é 100% estática
- [x] Validação parcial registrada pelo cliente na issue (ou agendada para próxima validação formal)
- [x] Documentação atualizada (README, ADR ou gh-pages) se necessário — N/A, conteúdo segue protótipo aprovado
- [x] Sem vulnerabilidades críticas abertas no SAST/linting de segurança

---

## Checklist de revisão (para o revisor)

- [x] Lógica de negócio correta segundo os critérios de aceitação da issue
- [x] Sem código morto ou TODO não rastreado
- [x] Nenhuma credencial, secret ou dado sensível exposto
- [x] Nomes de variáveis/funções seguem convenção do projeto

---

## Evidências

<img width="902" height="467" alt="image" src="https://github.com/user-attachments/assets/9923987a-44da-44e5-97fb-5079398ea2c1" />
<img width="1870" height="966" alt="image" src="https://github.com/user-attachments/assets/ea1c330d-54bb-47d5-bb8b-19735c28f57f" />

<img width="1766" height="864" alt="image" src="https://github.com/user-attachments/assets/08ed316d-2603-4126-95d0-c49633706579" />


---

## Notas para o revisor

- **Por que não usar Paraglide aqui:** o repo tem duas stacks de i18n vivas (Paraglide em `frontend/messages/*.json` e JSON flat em `frontend/src/lib/i18n/*.json`). A issue exigiu explicitamente o layout namespaced `pt/about.json` / `en/about.json`, então a página lê os JSONs diretamente em vez de passar pelo Paraglide. Consolidar isso vale um ADR separado,fora do escopo desta issue.
- **Por que o loader devolve os dois locales:** o CA exige troca PT↔EN em ≤ 1 clique sem reload (RNF13). O SSR inicializa via `locals.lang`, mas entregar ambos os locales no `data` permite que o toggle no header (já existente, via store `$lang`) apenas troque a referência reativa — zero round-trip.
- **Import relativo em `about.ts`:** o `vitest.config.ts` atual não resolve o alias `$lib`, então o import dos JSONs usa caminho relativo. Trocar para `$lib` exigiria configurar `resolve.alias` no vitest — preferi não tocar nisso aqui para manter o PR no escopo.
- **Sem chamada a API/DB:** conforme nota técnica da issue, nenhum endpoint backend ou query Supabase foi adicionado.
