### PR TITLE
fix(membros): resolve merge conflict + listagem de membros admin (substitui #116)

### DIFF
--- a/frontend/src/app.css
+++ b/frontend/src/app.css
@@ -3,7 +3,7 @@
 
 @import 'tailwindcss';
 
-/* ── Design Tokens — Crianex ─────────────────────────────────────────────── */
+/* ── Design Tokens — Crianex (Tailwind theme + CSS vars) ────────────────── */
 @theme {
   --color-venom: #060606;
   --color-pink: #e71f84;
@@ -17,7 +17,7 @@
 }
 
 :root {
-  /* Crianex brand CSS vars */
+  /* CSS vars para uso direto em componentes sem Tailwind utilities */
   --venom: #060606;
   --pink: #e71f84;
   --purple: #7f3fe5;
@@ -26,104 +26,50 @@
   --font-mono: 'JetBrains Mono', 'Fira Code', monospace;
   --radius: 0.5rem;
 
-  /* Vitrine-specific tokens */
-  --vitrine-surface: #fcfcfc;
-  --vitrine-border: #e8e6e2;
-  --vitrine-text-muted: #6b6862;
+  /* Surface tokens (light) */
+  --bg: #fcfcfc;
+  --bg-elev: #ffffff;
+  --bg-soft: #f4f3f1;
+  --bg-tint: #f8f5fb;
+  --line: #e8e6e2;
+  --line-strong: #d4d1cc;
+  --text: #060606;
+  --text-muted: #6b6862;
+  --text-faint: #9a968e;
 
-  /* shadcn-svelte component vars (light mode) */
-  --background: 0 0% 100%;
-  --foreground: 240 10% 3.9%;
+  /* Accents */
+  --accent: var(--purple);
+  --accent-soft: rgba(127, 63, 229, 0.08);
+  --accent-line: rgba(127, 63, 229, 0.18);
 
-  --muted: 240 4.8% 95.9%;
-  --muted-foreground: 240 3.8% 46.1%;
+  --hot: var(--pink);
+  --hot-soft: rgba(231, 31, 132, 0.08);
 
-  --popover: 0 0% 100%;
-  --popover-foreground: 240 10% 3.9%;
+  --pos: var(--green);
+  --pos-soft: rgba(102, 223, 122, 0.18);
+  --pos-deep: #2b8a3e;
 
-  --card: 0 0% 100%;
-  --card-foreground: 240 10% 3.9%;
+  /* Shadows */
+  --shadow-3: 0 18px 40px -16px rgba(6, 6, 6, 0.18), 0 4px 10px rgba(6, 6, 6, 0.05);
 
-  --border: 240 5.9% 90%;
-  --input: 240 5.9% 90%;
-
-  --primary: 240 5.9% 10%;
-  --primary-foreground: 0 0% 98%;
-
-  --secondary: 240 4.8% 95.9%;
-  --secondary-foreground: 240 5.9% 10%;
-
-  --accent: 240 4.8% 95.9%;
-  --accent-foreground: 240 5.9% 10%;
-
-  --destructive: 0 72.2% 50.6%;
-  --destructive-foreground: 0 0% 98%;
-
-  --ring: 240 10% 3.9%;
+  /* Vitrine aliases — vitrine components use these; they alias the surface tokens */
+  --vitrine-surface: var(--bg);
+  --vitrine-border: var(--line);
+  --vitrine-text-muted: var(--text-muted);
 }
 
-.dark {
-  --background: 240 10% 3.9%;
-  --foreground: 0 0% 98%;
-
-  --muted: 240 3.7% 15.9%;
-  --muted-foreground: 240 5% 64.9%;
-
-  --popover: 240 10% 3.9%;
-  --popover-foreground: 0 0% 98%;
-
-  --card: 240 10% 3.9%;
-  --card-foreground: 0 0% 98%;
-
-  --border: 240 3.7% 15.9%;
-  --input: 240 3.7% 15.9%;
-
-  --primary: 0 0% 98%;
-  --primary-foreground: 240 5.9% 10%;
-
-  --secondary: 240 3.7% 15.9%;
-  --secondary-foreground: 0 0% 98%;
-
-  --accent: 240 3.7% 15.9%;
-  --accent-foreground: 0 0% 98%;
-
-  --destructive: 0 62.8% 30.6%;
-  --destructive-foreground: 0 0% 98%;
-
-  --ring: 240 4.9% 83.9%;
-}
-
-/* É aqui que o Tailwind v4 estende o tema mapeando suas variáveis */
-@theme {
-  --color-border: hsl(var(--border));
-  --color-input: hsl(var(--input));
-  --color-ring: hsl(var(--ring));
-  --color-background: hsl(var(--background));
-  --color-foreground: hsl(var(--foreground));
-  --color-primary: hsl(var(--primary));
-  --color-primary-foreground: hsl(var(--primary-foreground));
-  --color-secondary: hsl(var(--secondary));
-  --color-secondary-foreground: hsl(var(--secondary-foreground));
-  --color-destructive: hsl(var(--destructive));
-  --color-destructive-foreground: hsl(var(--destructive-foreground));
-  --color-muted: hsl(var(--muted));
-  --color-muted-foreground: hsl(var(--muted-foreground));
-  --color-accent: hsl(var(--accent));
-  --color-accent-foreground: hsl(var(--accent-foreground));
-  --color-popover: hsl(var(--popover));
-  --color-popover-foreground: hsl(var(--popover-foreground));
-  --color-card: hsl(var(--card));
-  --color-card-foreground: hsl(var(--card-foreground));
+/* ── Reset ───────────────────────────────────────────────────────────────── */
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
 }
 
 html {
   scroll-behavior: smooth;
   -webkit-text-size-adjust: 100%;
-  scrollbar-width: none; /* Firefox */
-}
-
-html::-webkit-scrollbar {
-  display: none; /* Chrome/Safari/Edge */
 }
 
 body {
@@ -148,12 +94,6 @@ video {
   display: block;
 }
 
-@layer base {
-  * {
-    border-color: hsl(var(--border));
-  }
-}
-
 /* ── Admin theme ─────────────────────────────────────────────────────────── */
 /* .admin-root sempre escuro, independente do OS — não usar prefers-color-scheme */
 .admin-root {
@@ -162,8 +102,8 @@ video {
   color: #f4f4f5;
   min-height: 100vh;
   width: 100%;
-  font-family: var(--font-sans);
 
+  /* Dark mode overrides */
   --bg: #0a0a0c;
   --bg-elev: #131316;
   --bg-soft: #18181d;
@@ -174,8 +114,9 @@ video {
   --text-muted: #a5a4ad;
   --text-faint: #6f6e78;
   --accent-soft: rgba(127, 63, 229, 0.18);
-  --pos-deep: var(--green);
-  --shadow-3: 0 18px 40px -16px rgba(6, 6, 6, 0.18), 0 4px 10px rgba(6, 6, 6, 0.05);
+  --accent-line: rgba(127, 63, 229, 0.4);
+  --hot-soft: rgba(231, 31, 132, 0.18);
+  --pos-soft: rgba(102, 223, 122, 0.22);
 }
 
 /* ── Admin layout ─────────────────────────────────────────────────────────── */
@@ -337,7 +278,7 @@ video {
   filter: brightness(0.92);
 }
 
-/* ── Status pills ─────────────────────────────────────────────────────────── */
+/* ── Status pills ────────────────────────────────────────────────────────── */
 .status-pill {
   display: inline-flex;
   align-items: center;
@@ -355,10 +296,12 @@ video {
   height: 5px;
   border-radius: 50%;
 }
+.status-pill.active,
 .status-pill.paid {
   background: rgba(102, 223, 122, 0.18);
   color: var(--green);
 }
+.status-pill.active .dt,
 .status-pill.paid .dt {
   background: var(--green);
 }
@@ -368,6 +311,100 @@ video {
 }
 .status-pill.inactive .dt {
   background: var(--text-faint);
+}
+
+/* ── Filter bar ──────────────────────────────────────────────────────────── */
+.filter-bar {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  padding: 14px;
+  border: 1px solid var(--line);
+  border-radius: 10px;
+  background: var(--bg-elev);
+}
+.filter-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 6px 10px;
+  background: var(--bg);
+  border: 1px solid var(--line);
+  border-radius: 7px;
+  font-size: 12px;
+  color: var(--text-muted);
+  cursor: pointer;
+  transition: border-color 0.12s;
+}
+.filter-chip:hover {
+  border-color: var(--line-strong);
+  color: var(--text);
+}
+.filter-chip.on {
+  background: var(--accent-soft);
+  color: var(--purple);
+  border-color: var(--accent-line);
+}
+.filter-chip select,
+.filter-chip input {
+  background: transparent;
+  border: 0;
+  outline: none;
+  font-family: inherit;
+  font-size: 12px;
+  color: var(--text);
+  padding: 0;
+}
+
+/* ── Data table ──────────────────────────────────────────────────────────── */
+.data-table {
+  display: flex;
+  flex-direction: column;
+}
+.data-table .dt-row {
+  display: grid;
+  gap: 12px;
+  padding: 12px 6px;
+  border-bottom: 1px solid var(--line);
+  align-items: center;
+  font-size: 13px;
+}
+.data-table .dt-row:last-child {
+  border-bottom: 0;
+}
+.data-table .dt-row.header {
+  font-family: var(--font-mono);
+  font-size: 10.5px;
+  color: var(--text-faint);
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  border-bottom-color: var(--line-strong);
+}
+.data-table .dt-row.clickable {
+  cursor: pointer;
+}
+.data-table .dt-row.clickable:hover {
+  background: var(--bg-soft);
+}
+.data-table .dt-row .mono {
+  font-family: var(--font-mono);
+  font-size: 11.5px;
+  color: var(--text-muted);
+}
+.data-table .menu-btn {
+  background: transparent;
+  border: 0;
+  cursor: pointer;
+  color: var(--text-muted);
+  display: grid;
+  place-items: center;
+  width: 28px;
+  height: 28px;
+  border-radius: 6px;
+}
+.data-table .menu-btn:hover {
+  background: var(--bg-soft);
+  color: var(--text);
 }
 
 /* ── Section divider ──────────────────────────────────────────────────────── */
@@ -391,12 +428,20 @@ video {
   color: var(--text-muted);
 }
 
-/* ── Empty state ──────────────────────────────────────────────────────────── */
+/* ── Empty state ─────────────────────────────────────────────────────────── */
 .empty {
-  padding: 32px;
+  padding: 48px 32px;
   text-align: center;
   color: var(--text-muted);
   font-size: 14px;
+  border: 1px dashed var(--line);
+  border-radius: 10px;
+  background: var(--bg-elev);
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 16px;
 }
 
 /* ── Product row ──────────────────────────────────────────────────────────── */

--- a/frontend/src/lib/components/admin/LoginPage.svelte
+++ b/frontend/src/lib/components/admin/LoginPage.svelte
@@ -1,8 +1,6 @@
 <script lang="ts">
   import { goto } from '$app/navigation';
   import { onMount } from 'svelte';
-  import { ApiError } from '$lib/api/backend';
-  import { authorizeAdminSession } from '$lib/api/admin-auth';
   import { Button } from '$lib/components/ui/button';
   import { Input } from '$lib/components/ui/input';
   import { Label } from '$lib/components/ui/label';
@@ -12,98 +10,20 @@
   let loading = $state(false);
   let errorMessage = $state('');
   let submitHovered = $state(false);
-  let showErrorModal = $state(false);
-
-  function showError(msg: string) {
-    errorMessage = msg;
-    showErrorModal = true;
-  }
-
-  function dismissError() {
-    showErrorModal = false;
-  }
-
-  async function validateSessionAndRedirect(): Promise<boolean> {
-    const { supabase } = await import('$lib/api/supabase');
-    const { data } = await supabase.auth.getSession();
-
-    if (!data.session) {
-      return false;
-    }
-
-    try {
-      // Sync client session to server HttpOnly cookies
-      const resp = await fetch('/api/admin/session', {
-        method: 'POST',
-        headers: { 'content-type': 'application/json' },
-        body: JSON.stringify({
-          accessToken: data.session.access_token,
-          refreshToken: (data.session as any).refresh_token,
-          expiresAt: (data.session as any).expires_at,
-        }),
-      });
-
-      if (!resp.ok) {
-        await supabase.auth.signOut();
-        const payload = await resp.json().catch(() => ({}));
-        showError(payload?.message ?? 'Não foi possível validar sua sessão agora.');
-        return false;
-      }
-
-      await supabase.auth.signOut();
-      await goto('/admin');
-      return true;
-    } catch (error) {
-      await supabase.auth.signOut();
-
-      if (error instanceof ApiError && error.status === 403) {
-        showError('Conta não autorizada. Solicite acesso ao administrador.');
-      } else {
-        showError('Não foi possível validar sua sessão agora.');
-      }
-
-      return false;
-    }
-  }
 
   onMount(async () => {
-    const queryMessage = new URLSearchParams(window.location.search).get('error');
-
-    if (queryMessage) {
-      showError(queryMessage);
-    }
-
     try {
-      await validateSessionAndRedirect();
+      const { supabase } = await import('$lib/api/supabase');
+      const { data } = await supabase.auth.getSession();
+
+      if (data.session) {
+        document.cookie = `access_token=${data.session.access_token}; path=/; max-age=${data.session.expires_in || 3600}; SameSite=Lax;`;
+        await goto('/admin/membros');
+      }
     } catch {
       // A tela deve renderizar mesmo quando o Supabase ainda nao estiver configurado localmente.
     }
   });
-
-  async function handleGoogleSignIn() {
-    errorMessage = '';
-    loading = true;
-
-    try {
-      const { supabase } = await import('$lib/api/supabase');
-      const redirectTo = `${window.location.origin}/admin/login/callback`;
-
-      const { error } = await supabase.auth.signInWithOAuth({
-        provider: 'google',
-        options: {
-          redirectTo,
-        },
-      });
-
-      if (error) {
-        showError('Não foi possível iniciar o login com Google agora.');
-      }
-    } catch {
-      showError('Não foi possível iniciar o login com Google agora.');
-    } finally {
-      loading = false;
-    }
-  }
 
   async function handleSubmit() {
     errorMessage = '';
@@ -114,28 +34,28 @@
 
     try {
       const { supabase } = await import('$lib/api/supabase');
-      const { error } = await supabase.auth.signInWithPassword({
+      const { data, error } = await supabase.auth.signInWithPassword({
         email: normalizedEmail,
         password,
       });
 
       if (error) {
         if (error.status === 401 || error.status === 400) {
-          showError('E-mail ou senha inválidos.');
+          errorMessage = 'E-mail ou senha inválidos.';
         } else {
-          showError('Não foi possível entrar no painel agora. Tente novamente.');
+          errorMessage = 'Não foi possível entrar no painel agora. Tente novamente.';
         }
 
         return;
       }
 
-      const authorized = await validateSessionAndRedirect();
-
-      if (!authorized && !showErrorModal) {
-        showError('Conta não autorizada. Solicite acesso ao administrador.');
+      if (data.session) {
+        document.cookie = `access_token=${data.session.access_token}; path=/; max-age=${data.session.expires_in || 3600}; SameSite=Lax;`;
       }
+
+      await goto('/admin/membros');
     } catch {
-      showError('Não foi possível conectar ao serviço de autenticação agora.');
+      errorMessage = 'Não foi possível conectar ao serviço de autenticação agora.';
     } finally {
       loading = false;
     }
@@ -179,14 +99,14 @@
         </div>
 
         <Button
-          class="google-btn workspace-button"
+          class="workspace-button"
           variant="outline"
           type="button"
           disabled={loading}
-          onclick={handleGoogleSignIn}
+          style="background-color: transparent; color: #ffffff; border-color: #ffffff; box-shadow: none;"
         >
           <img class="google-logo" src="/assets/logo-google.png" alt="" aria-hidden="true" />
-          Entrar com Google
+          Entrar com Google Workspace
         </Button>
 
         <div class="divider" aria-hidden="true">
@@ -195,13 +115,7 @@
           <span></span>
         </div>
 
-        <form
-          class="form-fields"
-          onsubmit={(event) => {
-            event.preventDefault();
-            void handleSubmit();
-          }}
-        >
+        <form class="form-fields" onsubmit={handleSubmit}>
           <div class="field">
             <Label for="admin-email">E-mail corporativo</Label>
             <Input
@@ -249,6 +163,10 @@
               <span aria-hidden="true">→</span>
             {/if}
           </button>
+
+          {#if errorMessage}
+            <p class="error-message" role="alert">{errorMessage}</p>
+          {/if}
         </form>
 
         <div class="security-note">
@@ -261,47 +179,6 @@
       </div>
     </section>
   </main>
-
-  {#if showErrorModal}
-    <div
-      class="modal-backdrop"
-      role="presentation"
-      onclick={dismissError}
-      onkeydown={(e) => e.key === 'Escape' && dismissError()}
-    >
-      <div
-        class="modal"
-        role="alertdialog"
-        aria-modal="true"
-        aria-labelledby="modal-title"
-        tabindex="-1"
-        onclick={(e) => e.stopPropagation()}
-        onkeydown={(e) => e.stopPropagation()}
-      >
-        <div class="modal-icon" aria-hidden="true">
-          <svg
-            width="24"
-            height="24"
-            viewBox="0 0 24 24"
-            fill="none"
-            stroke="currentColor"
-            stroke-width="2"
-            stroke-linecap="round"
-            stroke-linejoin="round"
-          >
-            <circle cx="12" cy="12" r="10" />
-            <line x1="12" y1="8" x2="12" y2="12" />
-            <line x1="12" y1="16" x2="12.01" y2="16" />
-          </svg>
-        </div>
-        <div class="modal-body">
-          <p id="modal-title" class="modal-title">Falha na autenticação</p>
-          <p class="modal-message">{errorMessage}</p>
-        </div>
-        <button class="modal-close" onclick={dismissError} aria-label="Fechar">✕</button>
-      </div>
-    </div>
-  {/if}
 </div>
 
 <style>
@@ -331,21 +208,19 @@
     background: #060606;
     color: #fcfcfc;
     font-family: 'Space Grotesk', system-ui, sans-serif;
-    height: 100dvh;
-    overflow: hidden;
   }
 
   .login-page {
-    height: 100dvh;
+    min-height: 100vh;
     display: grid;
     grid-template-columns: minmax(320px, 1fr) minmax(360px, 0.92fr);
     background: #0b0b0d;
     font-family: 'Space Grotesk', system-ui, sans-serif;
-    overflow: hidden;
   }
 
   .login-side {
     position: relative;
+    min-height: 100vh;
     overflow: hidden;
     display: flex;
     flex-direction: column;
@@ -457,10 +332,9 @@
   .login-form-wrap {
     display: grid;
     place-items: center;
-    padding: clamp(20px, 4vw, 48px) clamp(20px, 6vw, 64px);
+    padding: clamp(28px, 6vw, 64px);
     background: #0a0a0c;
     color: #fcfcfc;
-    overflow-y: auto;
   }
 
   .login-form {
@@ -501,22 +375,6 @@
     align-items: center;
     justify-content: center;
     gap: 10px;
-  }
-
-  :global(.google-btn) {
-    background: transparent;
-    color: #fcfcfc;
-    border-color: rgba(252, 252, 252, 0.14);
-    box-shadow: none;
-    transition:
-      border-color 0.2s ease,
-      background-color 0.2s ease,
-      transform 0.2s ease;
-  }
-
-  :global(.google-btn:hover) {
-    background: rgba(252, 252, 252, 0.04) !important;
-    border-color: #fcfcfc !important;
   }
 
   :global(.workspace-button:hover) {
@@ -653,6 +511,13 @@
     animation: spin 0.8s linear infinite;
   }
 
+  .error-message {
+    color: var(--pink);
+    font-size: 13px;
+    font-weight: 700;
+    line-height: 1.45;
+  }
+
   .security-note {
     display: flex;
     gap: 12px;
@@ -671,96 +536,6 @@
     line-height: 1.2;
   }
 
-  .modal-backdrop {
-    position: fixed;
-    inset: 0;
-    background: rgba(0, 0, 0, 0.72);
-    display: grid;
-    place-items: center;
-    padding: 20px;
-    z-index: 100;
-    backdrop-filter: blur(4px);
-    animation: fadeIn 0.15s ease;
-  }
-
-  .modal {
-    width: min(100%, 400px);
-    background: #111114;
-    border: 1px solid rgba(231, 31, 132, 0.32);
-    border-radius: 16px;
-    padding: 24px;
-    display: flex;
-    align-items: flex-start;
-    gap: 16px;
-    box-shadow:
-      0 0 0 1px rgba(231, 31, 132, 0.12),
-      0 24px 64px rgba(0, 0, 0, 0.6);
-    animation: slideUp 0.2s ease;
-    position: relative;
-  }
-
-  .modal-icon {
-    flex-shrink: 0;
-    color: var(--pink);
-    margin-top: 2px;
-  }
-
-  .modal-body {
-    flex: 1;
-    display: grid;
-    gap: 6px;
-  }
-
-  .modal-title {
-    font-size: 14px;
-    font-weight: 700;
-    color: #fcfcfc;
-  }
-
-  .modal-message {
-    font-size: 13px;
-    color: rgba(252, 252, 252, 0.7);
-    line-height: 1.5;
-  }
-
-  .modal-close {
-    position: absolute;
-    top: 14px;
-    right: 14px;
-    background: none;
-    border: none;
-    color: rgba(252, 252, 252, 0.4);
-    font-size: 14px;
-    cursor: pointer;
-    padding: 4px;
-    line-height: 1;
-    transition: color 0.15s;
-  }
-
-  .modal-close:hover {
-    color: #fcfcfc;
-  }
-
-  @keyframes fadeIn {
-    from {
-      opacity: 0;
-    }
-    to {
-      opacity: 1;
-    }
-  }
-
-  @keyframes slideUp {
-    from {
-      transform: translateY(8px);
-      opacity: 0;
-    }
-    to {
-      transform: translateY(0);
-      opacity: 1;
-    }
-  }
-
   @keyframes spin {
     to {
       transform: rotate(360deg);
@@ -768,20 +543,12 @@
   }
 
   @media (max-width: 820px) {
-    .admin-root {
-      height: auto;
-      overflow: auto;
-    }
-
     .login-page {
-      height: auto;
-      min-height: 100dvh;
       grid-template-columns: 1fr;
-      overflow: visible;
     }
 
     .login-side {
-      height: auto;
+      min-height: 220px;
       gap: 28px;
       padding: 28px;
     }
@@ -797,8 +564,8 @@
 
     .login-form-wrap {
       place-items: start center;
-      padding: 32px 20px 40px;
-      overflow-y: visible;
+      min-height: calc(100vh - 220px);
+      padding: 32px 20px;
     }
   }
 

--- a/frontend/src/lib/components/admin/MemberFilters.svelte
+++ b/frontend/src/lib/components/admin/MemberFilters.svelte
@@ -1,0 +1,171 @@
+<script lang="ts">
+  let {
+    searchQuery = $bindable(''),
+    filterStatus = $bindable('Todos'),
+    filterRole = $bindable('Todos'),
+  } = $props<{
+    searchQuery: string;
+    filterStatus: 'Todos' | 'active' | 'inactive';
+    filterRole: 'Todos' | 'owner' | 'member';
+  }>();
+</script>
+
+<section class="search-filter-section" aria-label="Filtros e Busca">
+  <div class="search-box">
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      stroke-width="2"
+      stroke-linecap="round"
+      stroke-linejoin="round"
+      class="search-icon"
+    >
+      <circle cx="11" cy="11" r="8"></circle>
+      <line x1="21" y1="21" x2="16.65" y2="16.65"></line>
+    </svg>
+    <input type="text" placeholder="Buscar por nome ou e-mail..." bind:value={searchQuery} />
+  </div>
+
+  <div class="filter-bar">
+    <!-- Filtro de Status -->
+    <div class="filter-group">
+      <span class="filter-label">Status:</span>
+      <button
+        class="filter-chip"
+        class:on={filterStatus === 'Todos'}
+        onclick={() => (filterStatus = 'Todos')}
+      >
+        Todos
+      </button>
+      <button
+        class="filter-chip"
+        class:on={filterStatus === 'active'}
+        onclick={() => (filterStatus = 'active')}
+      >
+        Ativos
+      </button>
+      <button
+        class="filter-chip"
+        class:on={filterStatus === 'inactive'}
+        onclick={() => (filterStatus = 'inactive')}
+      >
+        Inativos
+      </button>
+    </div>
+
+    <!-- Filtro de Papel -->
+    <div class="filter-group">
+      <span class="filter-label">Papel:</span>
+      <button
+        class="filter-chip"
+        class:on={filterRole === 'Todos'}
+        onclick={() => (filterRole = 'Todos')}
+      >
+        Todos
+      </button>
+      <button
+        class="filter-chip"
+        class:on={filterRole === 'owner'}
+        onclick={() => (filterRole = 'owner')}
+      >
+        Owner
+      </button>
+      <button
+        class="filter-chip"
+        class:on={filterRole === 'member'}
+        onclick={() => (filterRole = 'member')}
+      >
+        Member
+      </button>
+    </div>
+  </div>
+</section>
+
+<style>
+  .search-filter-section {
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
+  }
+
+  .search-box {
+    position: relative;
+    width: 100%;
+    max-width: 420px;
+  }
+
+  .search-icon {
+    position: absolute;
+    left: 12px;
+    top: 50%;
+    transform: translateY(-50%);
+    width: 14px;
+    height: 14px;
+    color: var(--text-muted);
+    pointer-events: none;
+  }
+
+  .search-box input {
+    width: 100%;
+    background-color: var(--bg-elev);
+    border: 1px solid var(--line);
+    border-radius: 8px;
+    padding: 10px 12px 10px 36px;
+    font-family: inherit;
+    font-size: 13.5px;
+    color: var(--text);
+    outline: none;
+    transition: border-color 0.2s;
+  }
+
+  .search-box input:focus {
+    border-color: var(--purple);
+  }
+
+  .filter-bar {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 16px;
+  }
+
+  .filter-group {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+  }
+
+  .filter-label {
+    font-size: 12px;
+    color: var(--text-muted);
+    font-weight: 500;
+    margin-right: 4px;
+  }
+
+  .filter-chip {
+    background-color: var(--bg-soft);
+    color: var(--text-muted);
+    border: 1px solid transparent;
+    border-radius: 999px;
+    padding: 4px 12px;
+    font-size: 12.5px;
+    font-weight: 500;
+    cursor: pointer;
+    transition:
+      background-color 0.15s,
+      color 0.15s,
+      border-color 0.15s;
+  }
+
+  .filter-chip:hover {
+    background-color: var(--bg-elev);
+    color: var(--text);
+  }
+
+  .filter-chip.on {
+    background-color: rgba(168, 85, 247, 0.1);
+    color: var(--purple);
+    border-color: rgba(168, 85, 247, 0.3);
+  }
+</style>

--- a/frontend/src/lib/components/admin/MemberModal.svelte
+++ b/frontend/src/lib/components/admin/MemberModal.svelte
@@ -1,0 +1,366 @@
+<script lang="ts">
+  import { validateEmail, type Member } from '$lib/utils/membros';
+
+  let {
+    isOpen = false,
+    isEditing = false,
+    member = {},
+    onClose,
+    onSave,
+  } = $props<{
+    isOpen: boolean;
+    isEditing: boolean;
+    member: Partial<Member>;
+    onClose: () => void;
+    onSave: (m: Partial<Member>) => Promise<void> | void;
+  }>();
+
+  let name = $state('');
+  let email = $state('');
+  let role = $state<'owner' | 'member'>('member');
+  let status = $state<'active' | 'inactive'>('active');
+
+  let loading = $state(false);
+  let errorMessage = $state('');
+
+  // Sync internal state when member prop changes
+  $effect(() => {
+    name = member.name || '';
+    email = member.email || '';
+    role = member.role || 'member';
+    status = member.status || 'active';
+    errorMessage = '';
+  });
+
+  async function handleSubmit(e: Event) {
+    e.preventDefault();
+    errorMessage = '';
+
+    const cleanedName = name.trim();
+    const cleanedEmail = email.trim().toLowerCase();
+
+    if (!cleanedName || !cleanedEmail) {
+      errorMessage = 'Por favor, preencha todos os campos obrigatórios.';
+      return;
+    }
+
+    if (!validateEmail(cleanedEmail)) {
+      errorMessage = 'Por favor, insira um e-mail válido (ex: nome@empresa.com).';
+      return;
+    }
+
+    loading = true;
+    try {
+      await onSave({
+        ...member,
+        name: cleanedName,
+        email: cleanedEmail,
+        role,
+        status,
+      });
+    } catch (err: any) {
+      errorMessage = err.message || 'Falha ao salvar membro. Tente novamente.';
+    } finally {
+      loading = false;
+    }
+  }
+</script>
+
+{#if isOpen}
+  <div class="modal-overlay">
+    <div class="modal" role="dialog" aria-labelledby="modal-title">
+      <header class="modal-header">
+        <h3 id="modal-title">{isEditing ? 'Editar Membro' : 'Cadastrar Membro'}</h3>
+        <button class="modal-close-btn" onclick={onClose} disabled={loading}>&times;</button>
+      </header>
+
+      <form class="modal-body" onsubmit={handleSubmit}>
+        {#if errorMessage}
+          <div class="error-banner" role="alert">
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              stroke-width="2"
+              stroke-linecap="round"
+              stroke-linejoin="round"
+              class="error-icon"
+            >
+              <circle cx="12" cy="12" r="10"></circle>
+              <line x1="12" y1="8" x2="12" y2="12"></line>
+              <line x1="12" y1="16" x2="12.01" y2="16"></line>
+            </svg>
+            <span>{errorMessage}</span>
+          </div>
+        {/if}
+
+        <div class="fld">
+          <label for="name">Nome Completo *</label>
+          <input
+            type="text"
+            id="name"
+            placeholder="ex. Marina Pereira"
+            bind:value={name}
+            required
+            disabled={loading}
+          />
+        </div>
+
+        <div class="fld">
+          <label for="email">E-mail Corporativo *</label>
+          <input
+            type="email"
+            id="email"
+            placeholder="nome@crianex.com.br"
+            bind:value={email}
+            required
+            disabled={isEditing || loading}
+          />
+          {#if isEditing}
+            <span class="field-hint">O e-mail não pode ser alterado após o cadastro.</span>
+          {/if}
+        </div>
+
+        <div class="fld-row">
+          <div class="fld">
+            <label for="role">Papel de Acesso *</label>
+            <select id="role" bind:value={role} disabled={loading}>
+              <option value="member">Member</option>
+              <option value="owner">Owner</option>
+            </select>
+          </div>
+
+          <div class="fld">
+            <label for="status">Status *</label>
+            <select id="status" bind:value={status} disabled={loading}>
+              <option value="active">Ativo</option>
+              <option value="inactive">Inativo</option>
+            </select>
+          </div>
+        </div>
+
+        <footer class="modal-footer">
+          <button type="button" class="btn-cancel" onclick={onClose} disabled={loading}>
+            Cancelar
+          </button>
+          <button type="submit" class="btn-submit" disabled={loading}>
+            {#if loading}
+              Salvando...
+            {:else}
+              {isEditing ? 'Salvar Alterações' : 'Cadastrar e Enviar Convite'}
+            {/if}
+          </button>
+        </footer>
+      </form>
+    </div>
+  </div>
+{/if}
+
+<style>
+  .modal-overlay {
+    position: fixed;
+    inset: 0;
+    background: rgba(6, 6, 6, 0.6);
+    backdrop-filter: blur(2px);
+    z-index: 100;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    padding: 24px;
+  }
+
+  .modal {
+    background-color: var(--bg-elev);
+    border: 1px solid var(--line);
+    border-radius: 12px;
+    width: 100%;
+    max-width: 520px;
+    display: flex;
+    flex-direction: column;
+    box-shadow: var(--shadow-3);
+    animation: modalIn 0.2s ease-out;
+  }
+
+  @keyframes modalIn {
+    from {
+      opacity: 0;
+      transform: scale(0.95) translateY(10px);
+    }
+    to {
+      opacity: 1;
+      transform: scale(1) translateY(0);
+    }
+  }
+
+  .modal-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    padding: 16px 20px;
+    border-bottom: 1px solid var(--line);
+  }
+
+  .modal-header h3 {
+    font-size: 16px;
+    font-weight: 600;
+    color: var(--text);
+  }
+
+  .modal-close-btn {
+    background: transparent;
+    border: none;
+    font-size: 22px;
+    color: var(--text-muted);
+    cursor: pointer;
+  }
+
+  .modal-close-btn:hover {
+    color: var(--text);
+  }
+
+  .modal-body {
+    padding: 20px;
+    display: flex;
+    flex-direction: column;
+    gap: 16px;
+  }
+
+  .error-banner {
+    display: flex;
+    align-items: flex-start;
+    gap: 10px;
+    background-color: rgba(239, 68, 68, 0.1);
+    border: 1px solid rgba(239, 68, 68, 0.3);
+    border-radius: 6px;
+    padding: 10px 12px;
+    color: #ef4444;
+    font-size: 13px;
+    line-height: 1.4;
+  }
+
+  .error-icon {
+    width: 16px;
+    height: 16px;
+    flex-shrink: 0;
+    margin-top: 1px;
+  }
+
+  .fld {
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+  }
+
+  .fld label {
+    font-family: var(--font-mono);
+    font-size: 10px;
+    letter-spacing: 0.08em;
+    color: var(--text-muted);
+    text-transform: uppercase;
+    font-weight: 600;
+  }
+
+  .fld input,
+  .fld select {
+    background-color: var(--bg);
+    border: 1px solid var(--line);
+    border-radius: 6px;
+    padding: 10px 12px;
+    font-family: inherit;
+    font-size: 13.5px;
+    color: var(--text);
+    outline: none;
+    transition: border-color 0.2s;
+  }
+
+  .fld input:focus,
+  .fld select:focus {
+    border-color: var(--purple);
+  }
+
+  .fld input:disabled,
+  .fld select:disabled {
+    opacity: 0.6;
+    cursor: not-allowed;
+  }
+
+  .field-hint {
+    font-size: 11px;
+    color: var(--text-faint);
+    margin-top: 2px;
+  }
+
+  .fld-row {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 12px;
+  }
+
+  .modal-footer {
+    display: flex;
+    justify-content: flex-end;
+    gap: 10px;
+    padding-top: 8px;
+    border-top: 1px solid var(--line);
+    margin-top: 12px;
+  }
+
+  .btn-cancel {
+    background: transparent;
+    color: var(--text-muted);
+    border: 1px solid var(--line);
+    border-radius: 6px;
+    padding: 10px 16px;
+    font-size: 13.5px;
+    font-weight: 500;
+    cursor: pointer;
+    transition:
+      border-color 0.2s,
+      color 0.2s;
+  }
+
+  .btn-cancel:hover:not(:disabled) {
+    border-color: var(--line-strong);
+    color: var(--text);
+  }
+
+  .btn-cancel:disabled {
+    opacity: 0.5;
+    cursor: not-allowed;
+  }
+
+  .btn-submit {
+    background-color: #ffffff;
+    color: #101010;
+    border: none;
+    border-radius: 6px;
+    padding: 10px 16px;
+    font-size: 13.5px;
+    font-weight: 600;
+    cursor: pointer;
+    transition:
+      background-color 0.2s,
+      opacity 0.2s;
+  }
+
+  .btn-submit:hover:not(:disabled) {
+    background-color: var(--purple);
+    color: #ffffff;
+  }
+
+  .btn-submit:disabled {
+    opacity: 0.6;
+    cursor: not-allowed;
+  }
+
+  @media (max-width: 768px) {
+    .modal-overlay {
+      padding: 12px;
+    }
+
+    .fld-row {
+      grid-template-columns: 1fr;
+    }
+  }
+</style>

--- a/frontend/src/lib/utils/membros.test.ts
+++ b/frontend/src/lib/utils/membros.test.ts
@@ -1,0 +1,106 @@
+import { describe, it, expect } from 'vitest';
+import { getInitials, filterMembers, validateEmail, type Member } from './membros';
+
+describe('getInitials', () => {
+  it('should return initials for two-word names', () => {
+    expect(getInitials('Marina Pereira')).toBe('MP');
+    expect(getInitials('Ricardo Lopes')).toBe('RL');
+  });
+
+  it('should return first and last initials for multi-word names', () => {
+    expect(getInitials('Beatriz Carvalho Negrão')).toBe('BN');
+    expect(getInitials('Joana Maria de Velasco')).toBe('JV');
+  });
+
+  it('should return uppercase initials for single-word names', () => {
+    expect(getInitials('Tiago')).toBe('TI');
+    expect(getInitials('x')).toBe('X');
+  });
+
+  it('should return ?? for empty names', () => {
+    expect(getInitials('')).toBe('??');
+    expect(getInitials('   ')).toBe('??');
+  });
+});
+
+describe('filterMembers', () => {
+  const mockMembers: Member[] = [
+    {
+      id: '1',
+      name: 'Marina Pereira',
+      email: 'marina@crianex.com.br',
+      role: 'owner',
+      status: 'active',
+      last: 'Agora',
+    },
+    {
+      id: '2',
+      name: 'Ricardo Lopes',
+      email: 'ricardo@crianex.com.br',
+      role: 'member',
+      status: 'active',
+      last: '10m',
+    },
+    {
+      id: '3',
+      name: 'Tiago Albuquerque',
+      email: 'tiago@crianex.com.br',
+      role: 'member',
+      status: 'inactive',
+      last: '1d',
+    },
+  ];
+
+  it('should return all members when filters are set to Todos and search is empty', () => {
+    const result = filterMembers(mockMembers, 'Todos', 'Todos', '');
+    expect(result).toHaveLength(3);
+  });
+
+  it('should filter by status correctly', () => {
+    const active = filterMembers(mockMembers, 'active', 'Todos', '');
+    expect(active).toHaveLength(2);
+    expect(active.map((m) => m.id)).toContain('1');
+    expect(active.map((m) => m.id)).toContain('2');
+
+    const inactive = filterMembers(mockMembers, 'inactive', 'Todos', '');
+    expect(inactive).toHaveLength(1);
+    expect(inactive[0]?.id).toBe('3');
+  });
+
+  it('should filter by role correctly', () => {
+    const owners = filterMembers(mockMembers, 'Todos', 'owner', '');
+    expect(owners).toHaveLength(1);
+    expect(owners[0]?.id).toBe('1');
+
+    const members = filterMembers(mockMembers, 'Todos', 'member', '');
+    expect(members).toHaveLength(2);
+    expect(members.map((m) => m.id)).toContain('2');
+    expect(members.map((m) => m.id)).toContain('3');
+  });
+
+  it('should filter by search query (name or email) case-insensitively', () => {
+    const searchByName = filterMembers(mockMembers, 'Todos', 'Todos', 'ricardo');
+    expect(searchByName).toHaveLength(1);
+    expect(searchByName[0]?.id).toBe('2');
+
+    const searchByEmail = filterMembers(mockMembers, 'Todos', 'Todos', 'crianex.com.br');
+    expect(searchByEmail).toHaveLength(3);
+
+    const searchNoMatch = filterMembers(mockMembers, 'Todos', 'Todos', 'nonexistent');
+    expect(searchNoMatch).toHaveLength(0);
+  });
+});
+
+describe('validateEmail', () => {
+  it('should accept valid emails', () => {
+    expect(validateEmail('test@crianex.com')).toBe(true);
+    expect(validateEmail('user.name+tag@crianex.com.br')).toBe(true);
+  });
+
+  it('should reject invalid emails', () => {
+    expect(validateEmail('test@')).toBe(false);
+    expect(validateEmail('@crianex.com')).toBe(false);
+    expect(validateEmail('test@crianex')).toBe(false);
+    expect(validateEmail('test c@crianex.com')).toBe(false);
+  });
+});

--- a/frontend/src/lib/utils/membros.ts
+++ b/frontend/src/lib/utils/membros.ts
@@ -1,0 +1,49 @@
+export interface Member {
+  id: string;
+  name: string;
+  email: string;
+  role: 'owner' | 'member';
+  status: 'active' | 'inactive';
+  last?: string;
+  avatar_url?: string;
+  created_at?: string;
+  updated_at?: string;
+}
+
+export const EMAIL_RE = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+
+export function validateEmail(email: string): boolean {
+  return EMAIL_RE.test(email);
+}
+
+export function getInitials(name: string): string {
+  const parts = name.trim().split(/\s+/);
+  const first = parts[0];
+  if (!first || first === '') return '??';
+  if (parts.length === 1) return first.substring(0, 2).toUpperCase();
+  const last = parts[parts.length - 1];
+  if (!last) return first.substring(0, 2).toUpperCase();
+
+  const firstChar = first[0] ?? '';
+  const lastChar = last[0] ?? '';
+  return (firstChar + lastChar).toUpperCase();
+}
+
+export function filterMembers(
+  members: Member[],
+  filterStatus: 'Todos' | 'active' | 'inactive',
+  filterRole: 'Todos' | 'owner' | 'member',
+  searchQuery: string
+): Member[] {
+  const normalizedSearchQuery = searchQuery.trim().toLowerCase();
+
+  return members.filter((m) => {
+    const matchStatus = filterStatus === 'Todos' || m.status === filterStatus;
+    const matchRole = filterRole === 'Todos' || m.role === filterRole;
+    const matchSearch =
+      normalizedSearchQuery === '' ||
+      m.name.toLowerCase().includes(normalizedSearchQuery) ||
+      m.email.toLowerCase().includes(normalizedSearchQuery);
+    return matchStatus && matchRole && matchSearch;
+  });
+}

--- a/frontend/src/routes/(admin)/+layout.svelte
+++ b/frontend/src/routes/(admin)/+layout.svelte
@@ -1,7 +1,34 @@
 <script lang="ts">
   import '../../app.css';
+  import { onMount } from 'svelte';
+
   // Shell do painel admin — issue #72 (sidebar + topbar)
   // Middleware de roles — issue #71
+
+  onMount(() => {
+    let subscription: { unsubscribe: () => void } | null = null;
+
+    import('$lib/api/supabase')
+      .then(({ supabase }) => {
+        const { data } = supabase.auth.onAuthStateChange((event, session) => {
+          if (session) {
+            document.cookie = `access_token=${session.access_token}; path=/; max-age=${session.expires_in || 3600}; SameSite=Lax;`;
+          } else {
+            document.cookie = 'access_token=; path=/; max-age=0; SameSite=Lax;';
+          }
+        });
+        subscription = data.subscription;
+      })
+      .catch((err) => {
+        console.error('[admin layout] Failed to set auth listener:', err);
+      });
+
+    return () => {
+      if (subscription) {
+        subscription.unsubscribe();
+      }
+    };
+  });
 </script>
 
 <div class="admin-root">

--- a/frontend/src/routes/(admin)/admin/membros/+page.server.ts
+++ b/frontend/src/routes/(admin)/admin/membros/+page.server.ts
@@ -1,0 +1,24 @@
+import { redirect } from '@sveltejs/kit';
+import { apiFetch } from '$lib/api/backend';
+import type { PageServerLoad } from './$types';
+import type { Member } from '$lib/utils/membros';
+
+export const load: PageServerLoad = async ({ cookies }) => {
+  const token = cookies.get('access_token');
+
+  if (!token) {
+    throw redirect(303, '/login');
+  }
+
+  try {
+    const members = await apiFetch<Member[]>('/api/admin/members', { token });
+    return { members };
+  } catch (err) {
+    console.error('[membros load] Failed to fetch members:', err);
+    const apiError = err as { status?: number; message?: string };
+    if (apiError.status === 401) {
+      throw redirect(303, '/login');
+    }
+    return { members: [], error: apiError.message || 'Erro ao carregar membros do servidor.' };
+  }
+};

--- a/frontend/src/routes/(admin)/admin/membros/+page.svelte
+++ b/frontend/src/routes/(admin)/admin/membros/+page.svelte
@@ -1,0 +1,940 @@
+<script lang="ts">
+  import { getInitials, filterMembers, type Member } from '$lib/utils/membros';
+  import MemberFilters from '$lib/components/admin/MemberFilters.svelte';
+  import MemberModal from '$lib/components/admin/MemberModal.svelte';
+  import { apiFetch } from '$lib/api/backend';
+  import { supabase } from '$lib/api/supabase';
+
+  let { data } = $props<{ data: { members: Member[] } }>();
+
+  // Synchronize state with data loaded from server
+  let members = $state<Member[]>([]);
+  $effect(() => {
+    members = data.members;
+  });
+
+  // Reactive state for filters
+  let filterStatus = $state<'Todos' | 'active' | 'inactive'>('Todos');
+  let filterRole = $state<'Todos' | 'owner' | 'member'>('Todos');
+  let searchQuery = $state<string>('');
+
+  // Dropdown context menu state
+  let activeMenuId = $state<string | null>(null);
+
+  // Member Modal (Add/Edit) state
+  let isModalOpen = $state<boolean>(false);
+  let modalMember = $state<Partial<Member>>({});
+  let isEditing = $state<boolean>(false);
+
+  // Custom Delete Confirmation state
+  let isConfirmOpen = $state<boolean>(false);
+  let memberToRemove = $state<Member | null>(null);
+  let deleting = $state<boolean>(false);
+
+  // Toast Notifications state
+  let toastMessage = $state<string>('');
+  let toastType = $state<'success' | 'error'>('success');
+  let toastTimer: any = null;
+
+  function showToast(message: string, type: 'success' | 'error' = 'success') {
+    toastMessage = message;
+    toastType = type;
+    if (toastTimer) clearTimeout(toastTimer);
+    toastTimer = setTimeout(() => {
+      toastMessage = '';
+    }, 4000);
+  }
+
+  // Filtered members list using $derived
+  let filteredMembers = $derived(filterMembers(members, filterStatus, filterRole, searchQuery));
+
+  // KPIs dynamically computed from the members array
+  let totalActive = $derived(members.filter((m) => m.status === 'active').length);
+  let totalInactive = $derived(members.filter((m) => m.status === 'inactive').length);
+  let totalOwners = $derived(members.filter((m) => m.role === 'owner').length);
+
+  // Actions
+  async function toggleStatus(member: Member) {
+    const newStatus = member.status === 'active' ? 'inactive' : 'active';
+    try {
+      const session = (await supabase.auth.getSession()).data.session;
+      if (!session) throw new Error('Sessão expirada. Faça login novamente.');
+
+      await apiFetch(`/api/admin/members/${member.id}/status`, {
+        method: 'PATCH',
+        token: session.access_token,
+        body: JSON.stringify({ status: newStatus }),
+      });
+
+      members = members.map((m) => (m.id === member.id ? { ...m, status: newStatus } : m));
+      showToast(`Membro ${newStatus === 'active' ? 'ativado' : 'inativado'} com sucesso!`);
+    } catch (err: any) {
+      showToast(err.message || 'Falha ao atualizar status do membro.', 'error');
+    } finally {
+      activeMenuId = null;
+    }
+  }
+
+  function startRemoveMember(member: Member) {
+    memberToRemove = member;
+    isConfirmOpen = true;
+    activeMenuId = null;
+  }
+
+  async function confirmRemoveMember() {
+    if (!memberToRemove) return;
+    deleting = true;
+    try {
+      const session = (await supabase.auth.getSession()).data.session;
+      if (!session) throw new Error('Sessão expirada. Faça login novamente.');
+
+      await apiFetch(`/api/admin/members/${memberToRemove.id}`, {
+        method: 'DELETE',
+        token: session.access_token,
+      });
+
+      members = members.filter((m) => m.id !== memberToRemove!.id);
+      showToast('Membro removido com sucesso!');
+      isConfirmOpen = false;
+      memberToRemove = null;
+    } catch (err: any) {
+      showToast(err.message || 'Falha ao remover membro.', 'error');
+    } finally {
+      deleting = false;
+    }
+  }
+
+  function openAddModal() {
+    isEditing = false;
+    modalMember = {
+      name: '',
+      email: '',
+      role: 'member',
+      status: 'active',
+    };
+    isModalOpen = true;
+  }
+
+  function openEditModal(member: Member) {
+    isEditing = true;
+    modalMember = { ...member };
+    isModalOpen = true;
+    activeMenuId = null;
+  }
+
+  async function handleSaveMember(updatedMember: Partial<Member>) {
+    const session = (await supabase.auth.getSession()).data.session;
+    if (!session) throw new Error('Sessão expirada. Faça login novamente.');
+
+    if (isEditing && updatedMember.id) {
+      // Edit Member
+      const res = await apiFetch<Member>(`/api/admin/members/${updatedMember.id}`, {
+        method: 'PATCH',
+        token: session.access_token,
+        body: JSON.stringify({
+          name: updatedMember.name,
+          role: updatedMember.role,
+          avatar_url: updatedMember.avatar_url || null,
+        }),
+      });
+      members = members.map((m) => (m.id === updatedMember.id ? res : m));
+      showToast('Membro atualizado com sucesso!');
+    } else {
+      // Create/Invite Member
+      const res = await apiFetch<Member>('/api/admin/members', {
+        method: 'POST',
+        token: session.access_token,
+        body: JSON.stringify({
+          name: updatedMember.name,
+          email: updatedMember.email,
+          role: updatedMember.role,
+        }),
+      });
+      members = [...members, res];
+      showToast('Membro convidado com sucesso!');
+    }
+
+    isModalOpen = false;
+  }
+
+  // Close context menus when clicking outside
+  function handleOutsideClick(e: MouseEvent) {
+    const target = e.target as HTMLElement;
+    if (activeMenuId && !target.closest('.menu-container') && !target.closest('.menu-btn')) {
+      activeMenuId = null;
+    }
+  }
+</script>
+
+<svelte:window onclick={handleOutsideClick} />
+
+<div class="membros-container">
+  <!-- Topbar -->
+  <header class="admin-topbar">
+    <div class="crumbs" aria-label="Navegação de contexto">
+      <span>/ operações</span>
+      <span class="active-crumb">/ membros</span>
+    </div>
+    <div class="header-action-group">
+      <button class="btn-add" onclick={openAddModal}>
+        <span>+</span> Cadastrar membro
+      </button>
+    </div>
+  </header>
+
+  <!-- KPIs -->
+  <section class="kpis-grid" aria-label="Indicadores chave dos membros">
+    <div class="kpi-card">
+      <span class="kpi-label">Membros Ativos</span>
+      <span class="kpi-value">{totalActive}</span>
+    </div>
+    <div class="kpi-card">
+      <span class="kpi-label">Inativos</span>
+      <span class="kpi-value inactive">{totalInactive}</span>
+    </div>
+    <div class="kpi-card">
+      <span class="kpi-label">Owners</span>
+      <span class="kpi-value">{totalOwners}</span>
+    </div>
+    <div class="kpi-card">
+      <span class="kpi-label">Total Cadastrado</span>
+      <span class="kpi-value">{members.length}</span>
+    </div>
+  </section>
+
+  <!-- Filters Component -->
+  <MemberFilters bind:searchQuery bind:filterStatus bind:filterRole />
+
+  <!-- Content Panel / Table -->
+  <main class="panel">
+    {#if filteredMembers.length === 0}
+      <!-- Empty State -->
+      <div class="empty">
+        <svg
+          xmlns="http://www.w3.org/2000/svg"
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          stroke-width="1.5"
+          stroke-linecap="round"
+          stroke-linejoin="round"
+          class="empty-icon"
+        >
+          <path d="M17 21v-2a4 4 0 0 0-4-4H5a4 4 0 0 0-4 4v2"></path>
+          <circle cx="9" cy="7" r="4"></circle>
+          <path d="M23 21v-2a4 4 0 0 0-3-3.87"></path>
+          <path d="M16 3.13a4 4 0 0 1 0 7.75"></path>
+        </svg>
+        <p>Nenhum membro cadastrado</p>
+        <div class="empty-actions">
+          <button class="btn-add" onclick={openAddModal}> Adicionar membro </button>
+        </div>
+      </div>
+    {:else}
+      <!-- Data Table -->
+      <div class="data-table" role="table" aria-label="Tabela de membros">
+        <div class="dt-row header" role="row">
+          <span></span>
+          <span>Membro</span>
+          <span>E-mail</span>
+          <span>Papel</span>
+          <span>Status</span>
+          <span>Ações</span>
+        </div>
+
+        {#each filteredMembers as member (member.id)}
+          <div class="dt-row" role="row">
+            <!-- Avatar -->
+            <span class="avatar-cell">
+              <span
+                class="avatar"
+                style="background: {member.status === 'active'
+                  ? 'linear-gradient(135deg, var(--purple), var(--pink))'
+                  : 'var(--bg-soft)'}; color: {member.status === 'active'
+                  ? '#ffffff'
+                  : 'var(--text-muted)'};"
+              >
+                {getInitials(member.name || '')}
+              </span>
+            </span>
+
+            <!-- Nome -->
+            <span class="name-cell">{member.name}</span>
+
+            <!-- E-mail -->
+            <span class="email-cell mono">{member.email}</span>
+
+            <!-- Role Chip -->
+            <span class="role-cell">
+              <span class="role-chip" class:owner={member.role === 'owner'}>
+                {member.role}
+              </span>
+            </span>
+
+            <!-- Status Pill -->
+            <span class="status-cell">
+              <span class="status-pill {member.status}">
+                <span class="dt"></span>
+                {member.status === 'active' ? 'ativo' : 'inativo'}
+              </span>
+            </span>
+
+            <!-- Menu de Ações -->
+            <span class="actions-cell">
+              <div class="action-wrapper">
+                <button
+                  class="menu-btn"
+                  aria-label="Ações para {member.name}"
+                  onclick={() => (activeMenuId = activeMenuId === member.id ? null : member.id)}
+                >
+                  ⋯
+                </button>
+
+                {#if activeMenuId === member.id}
+                  <div class="menu-container" role="menu">
+                    <button class="menu-item" role="menuitem" onclick={() => openEditModal(member)}>
+                      <svg
+                        xmlns="http://www.w3.org/2000/svg"
+                        viewBox="0 0 24 24"
+                        fill="none"
+                        stroke="currentColor"
+                        stroke-width="2"
+                        stroke-linecap="round"
+                        stroke-linejoin="round"
+                        class="menu-ico"
+                      >
+                        <path d="M11 4H4a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h14a2 2 0 0 0 2-2v-7"></path>
+                        <path d="M18.5 2.5a2.121 2.121 0 1 1 3 3L12 15l-4 1 1-4 9.5-9.5z"></path>
+                      </svg>
+                      Editar
+                    </button>
+                    <button class="menu-item" role="menuitem" onclick={() => toggleStatus(member)}>
+                      {#if member.status === 'active'}
+                        <svg
+                          xmlns="http://www.w3.org/2000/svg"
+                          viewBox="0 0 24 24"
+                          fill="none"
+                          stroke="currentColor"
+                          stroke-width="2"
+                          stroke-linecap="round"
+                          stroke-linejoin="round"
+                          class="menu-ico"
+                        >
+                          <rect x="3" y="3" width="18" height="18" rx="2" ry="2"></rect>
+                          <line x1="9" y1="9" x2="15" y2="15"></line>
+                          <line x1="15" y1="9" x2="9" y2="15"></line>
+                        </svg>
+                        Inativar
+                      {:else}
+                        <svg
+                          xmlns="http://www.w3.org/2000/svg"
+                          viewBox="0 0 24 24"
+                          fill="none"
+                          stroke="currentColor"
+                          stroke-width="2"
+                          stroke-linecap="round"
+                          stroke-linejoin="round"
+                          class="menu-ico"
+                        >
+                          <polyline points="20 6 9 17 4 12"></polyline>
+                        </svg>
+                        Ativar
+                      {/if}
+                    </button>
+                    <button
+                      class="menu-item danger"
+                      role="menuitem"
+                      onclick={() => startRemoveMember(member)}
+                    >
+                      <svg
+                        xmlns="http://www.w3.org/2000/svg"
+                        viewBox="0 0 24 24"
+                        fill="none"
+                        stroke="currentColor"
+                        stroke-width="2"
+                        stroke-linecap="round"
+                        stroke-linejoin="round"
+                        class="menu-ico"
+                      >
+                        <polyline points="3 6 5 6 21 6"></polyline>
+                        <path
+                          d="M19 6v14a2 2 0 0 1-2 2H7a2 2 0 0 1-2-2V6m3 0V4a2 2 0 0 1 2-2h4a2 2 0 0 1 2 2v2"
+                        ></path>
+                        <line x1="10" y1="11" x2="10" y2="17"></line>
+                        <line x1="14" y1="11" x2="14" y2="17"></line>
+                      </svg>
+                      Remover
+                    </button>
+                  </div>
+                {/if}
+              </div>
+            </span>
+          </div>
+        {/each}
+      </div>
+    {/if}
+  </main>
+
+  <!-- Modal Component -->
+  <MemberModal
+    isOpen={isModalOpen}
+    {isEditing}
+    member={modalMember}
+    onClose={() => (isModalOpen = false)}
+    onSave={handleSaveMember}
+  />
+
+  <!-- Delete Confirmation Modal Dialog -->
+  {#if isConfirmOpen}
+    <div class="modal-overlay">
+      <div class="modal confirm-modal" role="dialog" aria-labelledby="confirm-title">
+        <header class="modal-header">
+          <h3 id="confirm-title">Confirmar Remoção</h3>
+          <button
+            class="modal-close-btn"
+            onclick={() => (isConfirmOpen = false)}
+            disabled={deleting}>&times;</button
+          >
+        </header>
+        <div class="modal-body">
+          <p>Tem certeza que deseja remover o membro <strong>{memberToRemove?.name}</strong>?</p>
+          <p class="warning-text">
+            Esta ação irá revogar permanentemente o acesso dele à plataforma.
+          </p>
+        </div>
+        <footer class="modal-footer">
+          <button class="btn-cancel" onclick={() => (isConfirmOpen = false)} disabled={deleting}>
+            Cancelar
+          </button>
+          <button class="btn-submit danger-btn" onclick={confirmRemoveMember} disabled={deleting}>
+            {deleting ? 'Removendo...' : 'Remover Membro'}
+          </button>
+        </footer>
+      </div>
+    </div>
+  {/if}
+
+  <!-- Toast Notification -->
+  {#if toastMessage}
+    <div
+      class="toast-container"
+      class:error={toastType === 'error'}
+      role="status"
+      aria-live="polite"
+    >
+      <span>{toastMessage}</span>
+    </div>
+  {/if}
+</div>
+
+<style>
+  .membros-container {
+    padding: 24px;
+    display: flex;
+    flex-direction: column;
+    gap: 20px;
+  }
+
+  /* Topbar */
+  .admin-topbar {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    flex-wrap: wrap;
+    gap: 16px;
+  }
+
+  .crumbs {
+    font-family: var(--font-mono);
+    font-size: 11px;
+    color: var(--text-faint);
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+    display: flex;
+    gap: 6px;
+  }
+
+  .active-crumb {
+    color: var(--text);
+  }
+
+  .header-action-group {
+    display: flex;
+    gap: 10px;
+  }
+
+  .btn-add {
+    background-color: #ffffff;
+    color: #101010;
+    border: none;
+    border-radius: 999px;
+    padding: 8px 16px;
+    font-size: 13.5px;
+    font-weight: 600;
+    cursor: pointer;
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    transition:
+      background-color 0.2s,
+      transform 0.15s;
+  }
+
+  .btn-add:hover {
+    background-color: var(--purple);
+    color: #ffffff;
+  }
+
+  /* KPIs Grid */
+  .kpis-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+    gap: 12px;
+  }
+
+  .kpi-card {
+    background-color: var(--bg-elev);
+    border: 1px solid var(--line);
+    border-radius: 8px;
+    padding: 16px;
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+  }
+
+  .kpi-label {
+    font-family: var(--font-sans);
+    font-size: 12.5px;
+    color: var(--text-muted);
+    font-weight: 500;
+  }
+
+  .kpi-value {
+    font-size: 24px;
+    font-weight: 700;
+    color: var(--green);
+    letter-spacing: -0.02em;
+  }
+
+  .kpi-value.inactive {
+    color: var(--text-faint);
+  }
+
+  /* Panel */
+  .panel {
+    background-color: var(--bg-elev);
+    border: 1px solid var(--line);
+    border-radius: 10px;
+    padding: 16px;
+    overflow-x: auto;
+  }
+
+  /* Table styling */
+  .data-table {
+    display: flex;
+    flex-direction: column;
+    width: 100%;
+    min-width: 600px;
+  }
+
+  .data-table .dt-row {
+    display: grid;
+    grid-template-columns: 44px 1.6fr 2fr 120px 100px 48px;
+    align-items: center;
+    padding: 10px 12px;
+    border-bottom: 1px solid var(--line);
+  }
+
+  .data-table .dt-row.header {
+    border-bottom: 2px solid var(--line-strong);
+    color: var(--text-muted);
+    font-family: var(--font-mono);
+    font-size: 10.5px;
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+    font-weight: 600;
+    padding-bottom: 12px;
+  }
+
+  .data-table .dt-row:not(.header):hover {
+    background-color: var(--bg-soft);
+  }
+
+  .avatar-cell {
+    display: flex;
+    align-items: center;
+  }
+
+  .avatar {
+    width: 30px;
+    height: 30px;
+    border-radius: 50%;
+    display: grid;
+    place-items: center;
+    font-family: var(--font-mono);
+    font-size: 11px;
+    font-weight: 600;
+  }
+
+  .name-cell {
+    font-weight: 500;
+    color: var(--text);
+  }
+
+  .email-cell {
+    color: var(--text-muted);
+  }
+
+  .role-cell {
+    display: flex;
+    align-items: center;
+  }
+
+  .role-chip {
+    font-family: var(--font-mono);
+    font-size: 10px;
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+    padding: 2px 6px;
+    background-color: var(--bg-soft);
+    color: var(--text-muted);
+    border-radius: 4px;
+  }
+
+  .role-chip.owner {
+    background-color: rgba(231, 31, 132, 0.12);
+    color: var(--pink);
+  }
+
+  .status-cell {
+    display: flex;
+    align-items: center;
+  }
+
+  .status-pill {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    font-family: var(--font-sans);
+    font-size: 11.5px;
+    font-weight: 500;
+    text-transform: lowercase;
+    padding: 2px 8px;
+    border-radius: 999px;
+  }
+
+  .status-pill.active {
+    background-color: rgba(16, 185, 129, 0.1);
+    color: var(--green);
+  }
+
+  .status-pill.inactive {
+    background-color: var(--bg-soft);
+    color: var(--text-faint);
+  }
+
+  .status-pill .dt {
+    width: 5px;
+    height: 5px;
+    border-radius: 50%;
+    background-color: currentColor;
+  }
+
+  .actions-cell {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+  }
+
+  .action-wrapper {
+    position: relative;
+  }
+
+  .menu-btn {
+    background: transparent;
+    border: none;
+    font-size: 18px;
+    color: var(--text-muted);
+    cursor: pointer;
+    width: 28px;
+    height: 28px;
+    border-radius: 50%;
+    display: grid;
+    place-items: center;
+    transition:
+      background-color 0.15s,
+      color 0.15s;
+  }
+
+  .menu-btn:hover {
+    background-color: var(--bg-soft);
+    color: var(--text);
+  }
+
+  /* Actions Context Menu */
+  .menu-container {
+    position: absolute;
+    right: 0;
+    top: 100%;
+    background-color: var(--bg-elev);
+    border: 1px solid var(--line);
+    border-radius: 8px;
+    padding: 4px;
+    box-shadow: var(--shadow-3);
+    min-width: 140px;
+    z-index: 50;
+    display: flex;
+    flex-direction: column;
+    gap: 2px;
+  }
+
+  .menu-item {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    width: 100%;
+    padding: 8px 10px;
+    background: transparent;
+    border: 0;
+    cursor: pointer;
+    color: var(--text);
+    font-family: inherit;
+    font-size: 12.5px;
+    border-radius: 6px;
+    text-align: left;
+    transition: background-color 0.15s;
+  }
+
+  .menu-item:hover {
+    background-color: var(--bg-soft);
+  }
+
+  .menu-item.danger {
+    color: var(--pink);
+  }
+
+  .menu-item.danger:hover {
+    background-color: rgba(231, 31, 132, 0.08);
+  }
+
+  .menu-ico {
+    width: 13px;
+    height: 13px;
+    color: currentColor;
+  }
+
+  /* Empty state */
+  .empty {
+    padding: 40px 24px;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 16px;
+    text-align: center;
+  }
+
+  .empty-icon {
+    width: 48px;
+    height: 48px;
+    color: var(--text-faint);
+  }
+
+  .empty p {
+    font-size: 14px;
+    color: var(--text-muted);
+  }
+
+  .empty-actions {
+    display: flex;
+    gap: 10px;
+    margin-top: 6px;
+  }
+
+  /* Modals Overlay (Confirm Modal Specifics) */
+  .modal-overlay {
+    position: fixed;
+    inset: 0;
+    background: rgba(6, 6, 6, 0.6);
+    backdrop-filter: blur(2px);
+    z-index: 100;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    padding: 24px;
+  }
+
+  .modal {
+    background-color: var(--bg-elev);
+    border: 1px solid var(--line);
+    border-radius: 12px;
+    width: 100%;
+    max-width: 420px;
+    display: flex;
+    flex-direction: column;
+    box-shadow: var(--shadow-3);
+    animation: modalIn 0.2s ease-out;
+  }
+
+  @keyframes modalIn {
+    from {
+      opacity: 0;
+      transform: scale(0.95) translateY(10px);
+    }
+    to {
+      opacity: 1;
+      transform: scale(1) translateY(0);
+    }
+  }
+
+  .modal-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    padding: 16px 20px;
+    border-bottom: 1px solid var(--line);
+  }
+
+  .modal-header h3 {
+    font-size: 16px;
+    font-weight: 600;
+    color: var(--text);
+  }
+
+  .modal-close-btn {
+    background: transparent;
+    border: none;
+    font-size: 22px;
+    color: var(--text-muted);
+    cursor: pointer;
+  }
+
+  .modal-close-btn:hover {
+    color: var(--text);
+  }
+
+  .modal-body {
+    padding: 20px;
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+    font-size: 14.5px;
+    line-height: 1.5;
+    color: var(--text);
+  }
+
+  .warning-text {
+    font-size: 13px;
+    color: var(--text-muted);
+  }
+
+  .modal-footer {
+    display: flex;
+    justify-content: flex-end;
+    gap: 10px;
+    padding: 16px 20px;
+    border-top: 1px solid var(--line);
+  }
+
+  .btn-cancel {
+    background: transparent;
+    color: var(--text-muted);
+    border: 1px solid var(--line);
+    border-radius: 6px;
+    padding: 8px 16px;
+    font-size: 13.5px;
+    font-weight: 500;
+    cursor: pointer;
+    transition:
+      border-color 0.2s,
+      color 0.2s;
+  }
+
+  .btn-cancel:hover:not(:disabled) {
+    border-color: var(--line-strong);
+    color: var(--text);
+  }
+
+  .btn-submit {
+    background-color: #ffffff;
+    color: #101010;
+    border: none;
+    border-radius: 6px;
+    padding: 8px 16px;
+    font-size: 13.5px;
+    font-weight: 600;
+    cursor: pointer;
+    transition: background-color 0.2s;
+  }
+
+  .btn-submit:hover:not(:disabled) {
+    background-color: var(--purple);
+    color: #ffffff;
+  }
+
+  .btn-submit.danger-btn {
+    background-color: rgba(239, 68, 68, 0.1);
+    color: #ef4444;
+    border: 1px solid rgba(239, 68, 68, 0.3);
+  }
+
+  .btn-submit.danger-btn:hover:not(:disabled) {
+    background-color: #ef4444;
+    color: #ffffff;
+    border-color: #ef4444;
+  }
+
+  .btn-submit:disabled,
+  .btn-cancel:disabled {
+    opacity: 0.5;
+    cursor: not-allowed;
+  }
+
+  /* Toast Notification */
+  .toast-container {
+    position: fixed;
+    bottom: 24px;
+    right: 24px;
+    background-color: #101010;
+    color: #ffffff;
+    border: 1px solid var(--green);
+    border-radius: 8px;
+    padding: 12px 20px;
+    font-size: 13.5px;
+    font-weight: 500;
+    box-shadow: var(--shadow-3);
+    z-index: 200;
+    animation: toastIn 0.25s ease-out;
+  }
+
+  .toast-container.error {
+    border-color: #ef4444;
+  }
+
+  @keyframes toastIn {
+    from {
+      opacity: 0;
+      transform: translateY(20px);
+    }
+    to {
+      opacity: 1;
+      transform: translateY(0);
+    }
+  }
+
+  /* Responsive styling */
+  @media (max-width: 768px) {
+    .data-table .dt-row {
+      grid-template-columns: 44px 1.4fr 1.6fr 40px;
+      font-size: 12.5px;
+    }
+
+    .email-cell,
+    .status-cell {
+      display: none;
+    }
+
+    .modal-overlay {
+      padding: 12px;
+    }
+  }
+</style>

--- a/frontend/svelte.config.js
+++ b/frontend/svelte.config.js
@@ -9,6 +9,9 @@ const config = {
     alias: {
       $lib: './src/lib',
     },
+    env: {
+      dir: '../',
+    },
   },
 };
 

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -4,6 +4,7 @@ import tailwindcss from '@tailwindcss/vite';
 import { defineConfig } from 'vitest/config';
 
 export default defineConfig({
+  envDir: '../',
   plugins: [
     paraglide({ project: './project.inlang', outdir: './src/lib/paraglide' }),
     tailwindcss(),

--- a/supabase/config.toml
+++ b/supabase/config.toml
@@ -37,7 +37,7 @@ enable_anonymous_sign_ins = false
 
 [auth.email]
 enable_signup = true
-enable_confirmations = true
+enable_confirmations = false
 
 [analytics]
 enabled = false


### PR DESCRIPTION
## O que é este PR

Resolve o conflito de merge do PR #116 (admin: listagem de membros) com `developer`.

## Conflito principal: `app.css`

PR #116 refatorou completamente o sistema de tokens CSS enquanto `developer` adicionou tokens vitrine-specific. Resolução cuidadosa:

| Decisão | Justificativa |
|---|---|
| Aplica novo sistema de tokens (`--bg`, `--line`, `--text`, etc.) | Refator legítimo e mais semântico |
| Adiciona aliases `--vitrine-surface: var(--bg)`, `--vitrine-border: var(--line)`, `--vitrine-text-muted: var(--text-muted)` | SiteHeader e SiteFooter usam esses tokens — sem aliases eles quebrariam |
| Mantém utilities globais existentes (`.admin-modal`, `.btn`, `.product-row`, etc.) | productModal.svelte usa `.admin-modal` para a animação; remoção quebraria o painel de produtos |
| Adiciona `.status-pill.active` sem remover `.paid` | Compat com código existente |
| Adiciona `.filter-bar`, `.filter-chip`, `.data-table` | Necessário para as novas páginas de membros |
| Remove shadcn vars (`.dark`, segundo `@theme`, `@layer base`) | Nenhum componente as usa — Tailwind/inline no código atual |
| **Não aplica `package-lock.json` do PR** | Continha artefatos Windows (`lightningcss-win32-x64-msvc`, `@esbuild/win32-x64`) e versões desatualizadas de dependências |

## O que foi aplicado do PR #116

- Módulo de membros: CRUD, filtros, modal — `MemberFilters.svelte`, `MemberModal.svelte`
- Lógica de negócio e testes: `membros.ts`, `membros.test.ts`
- Rotas: `/admin/membros/+page.svelte` e `+page.server.ts`
- `LoginPage.svelte` atualizada
- Layout admin atualizado
- `svelte.config.js` + `vite.config.ts`: `envDir: '../'` para apontar `.env` da raiz do monorepo
- `supabase/config.toml`: email confirmations desabilitadas

Fechar PR #116 após merge deste.