### PR TITLE
fix: restaura workflow multi-version de deploy do GitHub Pages

### DIFF
--- a/.github/gh-pages-root/index.html
+++ b/.github/gh-pages-root/index.html
@@ -1,0 +1,122 @@
+<!doctype html>
+<html lang="pt-BR">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Crianex Hub — Documentação</title>
+    <style>
+      * {
+        box-sizing: border-box;
+        margin: 0;
+        padding: 0;
+      }
+      body {
+        font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+        background: #0d1117;
+        color: #e6edf3;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        min-height: 100vh;
+        padding: 2rem;
+      }
+      .card-grid {
+        display: grid;
+        grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+        gap: 1.5rem;
+        max-width: 680px;
+        width: 100%;
+      }
+      header {
+        text-align: center;
+        margin-bottom: 2.5rem;
+      }
+      header h1 {
+        font-size: 1.8rem;
+        font-weight: 700;
+      }
+      header p {
+        color: #8b949e;
+        margin-top: 0.4rem;
+        font-size: 0.95rem;
+      }
+      .container {
+        max-width: 680px;
+        width: 100%;
+      }
+      a.card {
+        display: block;
+        background: #161b22;
+        border: 1px solid #30363d;
+        border-radius: 10px;
+        padding: 1.5rem 1.8rem;
+        text-decoration: none;
+        color: inherit;
+        transition:
+          border-color 0.2s,
+          background 0.2s;
+      }
+      a.card:hover {
+        border-color: #58a6ff;
+        background: #1c2128;
+      }
+      .card-label {
+        font-size: 0.7rem;
+        font-weight: 600;
+        letter-spacing: 0.08em;
+        text-transform: uppercase;
+        color: #8b949e;
+        margin-bottom: 0.5rem;
+      }
+      .card h2 {
+        font-size: 1.1rem;
+        font-weight: 600;
+      }
+      .card p {
+        margin-top: 0.4rem;
+        font-size: 0.875rem;
+        color: #8b949e;
+        line-height: 1.5;
+      }
+      .badge {
+        display: inline-block;
+        margin-top: 0.8rem;
+        padding: 0.2rem 0.6rem;
+        border-radius: 20px;
+        font-size: 0.75rem;
+        font-weight: 600;
+      }
+      .badge-main {
+        background: #0d4429;
+        color: #3fb950;
+      }
+      .badge-dev {
+        background: #161b22;
+        color: #58a6ff;
+        border: 1px solid #30363d;
+      }
+    </style>
+  </head>
+  <body>
+    <div class="container">
+      <header>
+        <h1>Crianex Hub</h1>
+        <p>Selecione a versão da documentação que deseja acessar</p>
+      </header>
+      <div class="card-grid">
+        <a class="card" href="./unidade2/">
+          <div class="card-label">branch: main</div>
+          <h2>Unidade 2</h2>
+          <p>Versão revisada pelo professor. Contém IT1 (Vitrine Pública) concluída.</p>
+          <span class="badge badge-main">✓ Revisado</span>
+        </a>
+        <a class="card" href="./unidade3/">
+          <div class="card-label">branch: developer</div>
+          <h2>Unidade 3</h2>
+          <p>Versão com IT2 (Lead Capture) e documentação da unidade 3 em andamento.</p>
+          <span class="badge badge-dev">Em andamento</span>
+        </a>
+      </div>
+    </div>
+  </body>
+</html>

--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -1,18 +1,27 @@
-name: CI
+name: Deploy Docs (Multi-version)
 
 on:
   push:
-    branches: ["main"]
+    branches: ['main', 'developer']
   workflow_dispatch:
 
 permissions:
   contents: write
 
 jobs:
-  deploy:
+  deploy-docs:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - name: Resolve deployment folder
+        id: meta
+        run: |
+          if [ "${{ github.ref_name }}" = "main" ]; then
+            echo "folder=unidade2" >> $GITHUB_OUTPUT
+          else
+            echo "folder=unidade3" >> $GITHUB_OUTPUT
+          fi
+
+      - uses: actions/checkout@v5
         with:
           fetch-depth: 0
 
@@ -20,19 +29,42 @@ jobs:
         with:
           python-version: 3.x
 
-      - name: Cache MkDocs dependencies
-        uses: actions/cache@v4
+      - name: Cache pip
+        uses: actions/cache@v5
         with:
-          key: mkdocs-cinder-${{ hashFiles('gh-pages/requirements.txt','.github/workflows/gh-pages.yml') }}
+          key: mkdocs-cinder-${{ hashFiles('gh-pages/requirements.txt', '.github/workflows/gh-pages.yml') }}
           path: ~/.cache/pip
-          restore-keys: |
-            mkdocs-cinder-
+          restore-keys: mkdocs-cinder-
 
       - name: Install dependencies
-        run: |
-          python -m pip install --upgrade pip
-          if [ -f gh-pages/requirements.txt ]; then pip install -r gh-pages/requirements.txt; fi
+        run: pip install -r gh-pages/requirements.txt
 
-      - name: Deploy to GitHub Pages
-        run: mkdocs gh-deploy --force --config-file gh-pages/mkdocs.yml
-        
+      - name: Build docs
+        run: mkdocs build --config-file gh-pages/mkdocs.yml --site-dir $GITHUB_WORKSPACE/site
+
+      - name: Deploy to /${{ steps.meta.outputs.folder }}
+        uses: peaceiris/actions-gh-pages@v4
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./site
+          destination_dir: ${{ steps.meta.outputs.folder }}
+          keep_files: true
+
+  deploy-root-index:
+    runs-on: ubuntu-latest
+    if: github.ref_name == 'main'
+    needs: deploy-docs
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Create root index
+        run: |
+          mkdir -p ./root-site
+          cp .github/gh-pages-root/index.html ./root-site/index.html
+
+      - name: Deploy root index
+        uses: peaceiris/actions-gh-pages@v4
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./root-site
+          keep_files: true


### PR DESCRIPTION
## Resumo
- `.github/workflows/gh-pages.yml` em `main` ainda estava na versão antiga (`mkdocs gh-deploy --force`), que reescreve a branch `gh-pages` inteira a partir da raiz.
- Na última vez que houve push em `main`, esse workflow rodou e **apagou o diretório `unidade3/`** (gerado pelo workflow correto a partir de `developer`), quebrando https://mdsreq-fga-unb.github.io/REQ-2026.1-T02-Crianex-/unidade3/
- `developer` já tem a versão correta ("Deploy Docs (Multi-version)"), que builda com `destination_dir` + `keep_files: true`, preservando `unidade2/`, `unidade3/` e `unidade4/` simultaneamente.

## Mudanças
- Sincroniza `.github/workflows/gh-pages.yml` de `main` com a versão multi-version de `developer`.
- Adiciona `.github/gh-pages-root/index.html`, usado pelo job `deploy-root-index` (faltava em `main`).

## Test plan
- [x] Disparei manualmente o workflow correto em `developer` (`gh workflow run gh-pages.yml --ref developer`) para restaurar `unidade3/` imediatamente — não depende deste PR.
- [ ] Após merge, validar que um novo push em `main` deploya em `unidade2/` sem apagar `unidade3/`/`unidade4/`.