### PR TITLE
feat(crm): cria schema de crm_columns com invariantes de coluna padrão e RLS admin-only (#181)

### DIFF
--- a/backend/tests/database/crm_columns.test.ts
+++ b/backend/tests/database/crm_columns.test.ts
@@ -1,0 +1,51 @@
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+import { describe, expect, it } from 'vitest';
+
+const migrationPath = resolve(
+  import.meta.dirname,
+  '../../../supabase/migrations/20260622000100_create_crm_columns_table.sql'
+);
+
+const migrationSql = readFileSync(migrationPath, 'utf8');
+
+describe('crm_columns migration', () => {
+  it('cria a tabela crm_columns com as colunas obrigatórias', () => {
+    expect(migrationSql).toContain('create table public.crm_columns');
+    expect(migrationSql).toContain('nome text not null');
+    expect(migrationSql).toContain('ordem integer not null');
+    expect(migrationSql).toContain('is_default boolean default false not null');
+    expect(migrationSql).toContain('created_at timestamp with time zone');
+  });
+
+  it('garante no máximo 1 coluna default via índice único parcial', () => {
+    expect(migrationSql).toContain('create unique index crm_columns_single_default_idx');
+    expect(migrationSql).toContain('on public.crm_columns (is_default)');
+    expect(migrationSql).toContain('where is_default = true');
+  });
+
+  it('garante as invariantes de "≥1 coluna" e "exatamente 1 default" via trigger', () => {
+    expect(migrationSql).toContain('public.check_crm_columns_invariants()');
+    expect(migrationSql).toContain('deve existir ao menos 1 coluna');
+    expect(migrationSql).toContain('deve existir exatamente 1 coluna marcada como is_default');
+    expect(migrationSql).toContain('create constraint trigger crm_columns_invariants_on_update');
+    expect(migrationSql).toContain('create constraint trigger crm_columns_invariants_on_delete');
+    expect(migrationSql).toContain('deferrable initially immediate');
+  });
+
+  it('habilita RLS com policy admin-only e revoga acesso de anon', () => {
+    expect(migrationSql).toContain('alter table public.crm_columns enable row level security');
+    expect(migrationSql).toContain(
+      'Permitir leitura e gerenciamento de colunas do CRM para owners'
+    );
+    expect(migrationSql).toContain('using (public.is_owner(auth.uid()))');
+    expect(migrationSql).toContain('with check (public.is_owner(auth.uid()))');
+    expect(migrationSql).toContain('revoke all on table public.crm_columns from anon');
+  });
+
+  it('faz seed inicial garantindo ao menos 1 coluna default', () => {
+    expect(migrationSql).toContain('insert into public.crm_columns (nome, ordem, is_default)');
+    expect(migrationSql).toContain("('Novo Lead', 1, true)");
+  });
+});

--- a/supabase/migrations/20260622000100_create_crm_columns_table.sql
+++ b/supabase/migrations/20260622000100_create_crm_columns_table.sql
@@ -1,0 +1,78 @@
+-- Tabela crm_columns (F20 — Gerenciar colunas do funil) — issue #181
+-- Invariantes garantidas por constraint/trigger (não dependem da validação da API):
+--   1. Deve existir sempre ao menos 1 coluna
+--   2. Deve existir sempre exatamente 1 coluna marcada como is_default
+
+create table public.crm_columns (
+    id uuid default gen_random_uuid() primary key,
+    nome text not null,
+    ordem integer not null,
+    is_default boolean default false not null,
+    created_at timestamp with time zone default timezone('utc'::text, now()) not null
+);
+
+-- Garante "no máximo 1 default" de forma imediata (índice único parcial)
+create unique index crm_columns_single_default_idx
+on public.crm_columns (is_default)
+where is_default = true;
+
+-- Garante "ao menos 1 coluna" e "exatamente 1 default" ao final de cada
+-- UPDATE/DELETE, permitindo trocas de default dentro da mesma transação
+-- (ex.: marcar uma nova coluna como default e desmarcar a antiga).
+create or replace function public.check_crm_columns_invariants()
+returns trigger
+language plpgsql
+as $$
+begin
+    if (select count(*) from public.crm_columns) = 0 then
+        raise exception 'crm_columns: deve existir ao menos 1 coluna';
+    end if;
+
+    if (select count(*) from public.crm_columns where is_default = true) <> 1 then
+        raise exception 'crm_columns: deve existir exatamente 1 coluna marcada como is_default';
+    end if;
+
+    return null;
+end;
+$$;
+
+-- "initially immediate" (padrão) avalia a invariante ao final de cada
+-- statement (não a cada linha), permitindo UPDATEs multi-linha que trocam o
+-- default atomicamente dentro de um único comando.
+create constraint trigger crm_columns_invariants_on_update
+after update on public.crm_columns
+deferrable initially immediate
+for each row
+execute function public.check_crm_columns_invariants();
+
+create constraint trigger crm_columns_invariants_on_delete
+after delete on public.crm_columns
+deferrable initially immediate
+for each row
+execute function public.check_crm_columns_invariants();
+
+create index idx_crm_columns_ordem on public.crm_columns (ordem);
+
+alter table public.crm_columns enable row level security;
+
+create policy "Permitir leitura e gerenciamento de colunas do CRM para owners"
+on public.crm_columns
+for all
+to authenticated
+using (public.is_owner(auth.uid()))
+with check (public.is_owner(auth.uid()));
+
+-- Revoga acesso default do PostgREST: anon não deve nem aparecer na
+-- introspecção do schema. authenticated mantém grant de tabela, mas a RLS
+-- acima já restringe leitura/escrita a quem é owner.
+revoke all on table public.crm_columns from anon;
+grant all on table public.crm_columns to authenticated;
+grant all on table public.crm_columns to service_role;
+
+-- Seed inicial — necessário para que demais features do CRM (F19/F21) possam
+-- operar, já que toda issue do funil depende de ao menos 1 coluna existente.
+insert into public.crm_columns (nome, ordem, is_default) values
+    ('Novo Lead', 1, true),
+    ('Em Contato', 2, false),
+    ('Proposta', 3, false),
+    ('Fechado', 4, false);

--- a/supabase/tests/crm_columns_test.sql
+++ b/supabase/tests/crm_columns_test.sql
@@ -1,0 +1,102 @@
+-- pgTAP tests for crm_columns table (issue #181 / CP1)
+-- Run with: supabase test db
+BEGIN;
+
+SELECT plan(21);
+
+-- ── Schema ────────────────────────────────────────────────────────────────────
+
+SELECT has_table('public', 'crm_columns', 'crm_columns table exists');
+
+SELECT has_column('public', 'crm_columns', 'id',         'has id');
+SELECT has_column('public', 'crm_columns', 'nome',       'has nome');
+SELECT has_column('public', 'crm_columns', 'ordem',      'has ordem');
+SELECT has_column('public', 'crm_columns', 'is_default', 'has is_default');
+SELECT has_column('public', 'crm_columns', 'created_at', 'has created_at');
+
+SELECT col_not_null('public', 'crm_columns', 'nome',       'nome is NOT NULL');
+SELECT col_not_null('public', 'crm_columns', 'ordem',      'ordem is NOT NULL');
+SELECT col_not_null('public', 'crm_columns', 'is_default', 'is_default is NOT NULL');
+SELECT col_not_null('public', 'crm_columns', 'created_at', 'created_at is NOT NULL');
+
+-- ── RLS & policies ───────────────────────────────────────────────────────────
+
+SELECT ok(
+  (SELECT relrowsecurity FROM pg_class
+   WHERE relname = 'crm_columns' AND relnamespace = 'public'::regnamespace),
+  'RLS is enabled on crm_columns'
+);
+
+SELECT ok(
+  EXISTS (SELECT 1 FROM pg_policies
+          WHERE schemaname = 'public' AND tablename = 'crm_columns'
+            AND policyname = 'Permitir leitura e gerenciamento de colunas do CRM para owners'),
+  'admin-only policy exists'
+);
+
+SELECT ok(
+  NOT has_table_privilege('anon', 'public.crm_columns', 'SELECT'),
+  'anon does not have SELECT privilege'
+);
+
+-- ── Seed ──────────────────────────────────────────────────────────────────────
+
+SELECT ok(
+  (SELECT count(*) FROM public.crm_columns) >= 1,
+  'seed inicial garante ao menos 1 coluna'
+);
+
+SELECT ok(
+  (SELECT count(*) FROM public.crm_columns WHERE is_default = true) = 1,
+  'seed inicial garante exatamente 1 coluna default'
+);
+
+-- ── Invariant: no máximo 1 default (índice único parcial, imediato) ──────────
+
+SELECT throws_ok(
+  $$INSERT INTO public.crm_columns (nome, ordem, is_default) VALUES ('Duplicada', 99, true)$$,
+  '23505',
+  NULL,
+  'inserir uma segunda coluna default é rejeitado pelo índice único parcial'
+);
+
+-- ── Invariant: exatamente 1 default (trigger, ao final do statement) ─────────
+
+SELECT throws_ok(
+  $$UPDATE public.crm_columns SET is_default = false WHERE is_default = true$$,
+  NULL,
+  'crm_columns: deve existir exatamente 1 coluna marcada como is_default',
+  'remover o único default sem substituí-lo é rejeitado pelo trigger'
+);
+
+-- Troca de default dentro da mesma transação deve ser permitida
+SELECT lives_ok(
+  $$UPDATE public.crm_columns
+    SET is_default = (nome = 'Em Contato')
+    WHERE nome IN ('Novo Lead', 'Em Contato')$$,
+  'trocar a coluna default em um único statement é permitido'
+);
+
+SELECT ok(
+  (SELECT is_default FROM public.crm_columns WHERE nome = 'Em Contato') = true,
+  'nova coluna default foi aplicada corretamente'
+);
+
+-- ── Invariant: ao menos 1 coluna (trigger) ────────────────────────────────────
+
+SELECT throws_ok(
+  $$DELETE FROM public.crm_columns$$,
+  NULL,
+  'crm_columns: deve existir ao menos 1 coluna',
+  'remover todas as colunas é rejeitado pelo trigger'
+);
+
+SELECT throws_ok(
+  $$DELETE FROM public.crm_columns WHERE is_default = true$$,
+  NULL,
+  'crm_columns: deve existir exatamente 1 coluna marcada como is_default',
+  'remover a coluna default (deixando 0 defaults) é rejeitado pelo trigger'
+);
+
+SELECT * FROM finish();
+ROLLBACK;


### PR DESCRIPTION
## Feature entregue
`Criar schema de crm_columns com invariantes de coluna padrão e RLS admin-only`

| Campo | Valor |
|---|---|
| **CP** | CP1 — CRM Interno de Clientes (Kanban) |
| **Iteração** | IT2 — Lead Capture |
| **Feature pai** | #176 — [F20] Gerenciar colunas do funil |
| **Issue** | Closes #181 |
| **Chief Programmer** | @Phill-Chill |

---
## O que foi implementado
- Migration `20260622000100_create_crm_columns_table.sql` criando a tabela `crm_columns` (`id`, `nome`, `ordem`, `is_default`, `created_at`)
- Invariante **"no máximo 1 coluna default"** garantida de forma imediata por índice único parcial (`crm_columns_single_default_idx ... where is_default = true`)
- Invariante **"exatamente 1 default"** e **"≥1 coluna"** garantidas por trigger de constraint (`check_crm_columns_invariants`) que roda ao final de cada `UPDATE`/`DELETE` — `deferrable initially immediate`, permitindo trocar o default atomicamente dentro de um único `UPDATE` multi-linha, mas rejeitando qualquer statement que deixe o estado inconsistente
- RLS habilitado com policy única admin-only (`for all ... using/with check (public.is_owner(auth.uid()))`), reaproveitando a função `is_owner` já existente
- `revoke all ... from anon` para a tabela não aparecer na introspecção de schema do PostgREST para visitantes anônimos (mesmo padrão usado em `leads`)
- Seed inicial com 4 colunas padrão do funil (`Novo Lead` como default, `Em Contato`, `Proposta`, `Fechado`) — necessário para que as demais sub-issues de F19/F20 (#177 e seguintes) já tenham um funil operável

---
## Testes automatizados
- `supabase/tests/crm_columns_test.sql` — suíte pgTAP (21 assertions): schema/colunas/NOT NULL, RLS habilitado, policy admin-only, ausência de privilégio `anon`, seed inicial consistente, rejeição de 2º default (índice único), rejeição de remover o único default sem substituí-lo, troca de default permitida no mesmo statement, rejeição de apagar todas as colunas, rejeição de apagar a coluna default isolada
- `backend/tests/database/crm_columns.test.ts` — testes estáticos da migration (vitest), seguindo o padrão já usado para `products`/`faq_*`

---
## DoD — Definition of Done
- [x] Critérios de aceite todos validados (Given/When/Then cobertos)
- [x] Testes automatizados passando (`supabase test db` local: 45/45 · `vitest`: 5/5 do arquivo novo)
- [x] Lint sem erros (ESLint + Prettier)
- [x] CI verde (build + testes + lint)
- [x] Migration de banco aplicada em ambiente local (Supabase CLI) sem erros
- [ ] Validação parcial registrada pelo cliente na issue (ou agendada para próxima validação formal)
- [ ] Documentação atualizada (README, ADR ou gh-pages) se necessário
- [x] Sem vulnerabilidades críticas abertas no SAST/linting de segurança

---
## Checklist de revisão (para o revisor)
- [ ] Lógica de negócio correta segundo os critérios de aceitação da issue
- [ ] Sem código morto ou TODO não rastreado
- [ ] Nenhuma credencial, secret ou dado sensível exposto
- [ ] Nomes de variáveis/funções seguem convenção do projeto

---
## Evidências
<img width="1113" height="312" alt="image" src="https://github.com/user-attachments/assets/cab4f31c-e47e-413e-a71e-342cdba5f012" />


---
## Notas para o revisor
- O CLI local estava com um volume Docker do Postgres incompatível (v15 vs v17); foi recriado do zero — não afeta o projeto remoto da equipe
- `is_owner(auth.uid())` é a mesma função SECURITY DEFINER já usada em `products`/`faq_*` para policies admin-only — nenhuma função nova de checagem de role foi criada
- A constraint trigger usa `deferrable initially immediate` (não `deferred`): a checagem ocorre ao final do statement que a disparou, não apenas no commit — isso é o que permite rejeitar um `UPDATE`/`DELETE` isolado mas ainda aceitar a troca de default feita em um único `UPDATE` multi-linha
- Bloqueado por nada; bloqueia as sub-issues 2, 3 e 4 de F20 e a sub-issue 1 de F19 (#177), que dependem desta tabela existir