### PR TITLE
feat(notifications): cria schema de notifications com RLS admin-only (#186)

### DIFF
--- a/supabase/migrations/20260628000100_create_notifications.sql
+++ b/supabase/migrations/20260628000100_create_notifications.sql
@@ -1,0 +1,38 @@
+-- Migration: create notifications table (F07 · CP9 — Sistema de Notificações)
+-- Ref: sub-issue de schema da feature #179. Base para F07 (sub-issues 2/3), F08 e F19.
+-- RLS: admin-only (app_metadata.role = 'owner'), igual a clients/leads (RNF09).
+
+CREATE TABLE public.notifications (
+  id          uuid        PRIMARY KEY DEFAULT gen_random_uuid(),
+  tipo        text        NOT NULL CHECK (length(trim(tipo)) > 0),
+  conteudo    text        NOT NULL CHECK (length(trim(conteudo)) > 0),
+  status      text        NOT NULL DEFAULT 'unread'
+                          CHECK (status IN ('unread', 'read')),
+  created_at  timestamptz NOT NULL DEFAULT now()
+);
+
+COMMENT ON TABLE public.notifications IS
+  'Histórico de notificações geradas por eventos-chave (ex.: novo lead). '
+  'status alterna unread/read; base para F07/F08/F19.';
+
+-- RNF03: listagem por status + data ordenada por mais recentes em ≤ 2s.
+CREATE INDEX notifications_status_created_at_idx
+  ON public.notifications (status, created_at DESC);
+
+-- ── Grants ───────────────────────────────────────────────────────────────────
+-- service_role bypasses RLS (backend admin queries); authenticated is gated by
+-- the owner-only policy below. anon is revoked to hide the table from PostgREST.
+GRANT ALL ON public.notifications TO service_role;
+GRANT SELECT, INSERT, UPDATE, DELETE ON public.notifications TO authenticated;
+REVOKE ALL ON public.notifications FROM anon;
+
+-- ── RLS ──────────────────────────────────────────────────────────────────────
+ALTER TABLE public.notifications ENABLE ROW LEVEL SECURITY;
+
+-- Only owner-role admins can manage notifications (RNF09).
+-- (SELECT auth.jwt()) caches the JWT once per query instead of per row.
+CREATE POLICY notifications_owner_all ON public.notifications
+  FOR ALL
+  TO authenticated
+  USING      ((SELECT auth.jwt()) -> 'app_metadata' ->> 'role' = 'owner')
+  WITH CHECK ((SELECT auth.jwt()) -> 'app_metadata' ->> 'role' = 'owner');

--- a/supabase/seed.sql
+++ b/supabase/seed.sql
@@ -22,3 +22,8 @@
 --   ('Geral',     'General',  'geral'),
 --   ('Produtos',  'Products', 'produtos'),
 --   ('Suporte',   'Support',  'suporte');
+
+-- ── Notifications (F07 — sistema de notificações) ────────────────────────────
+-- INSERT INTO public.notifications (tipo, conteudo, status) VALUES
+--   ('novo_lead', 'Novo lead capturado: João Silva',    'unread'),
+--   ('novo_lead', 'Novo lead capturado: Maria Souza',   'read');

--- a/supabase/tests/notifications_test.sql
+++ b/supabase/tests/notifications_test.sql
@@ -1,0 +1,81 @@
+-- pgTAP tests for notifications table (sub-issue de schema da F07 / CP9)
+-- Run with: supabase test db
+BEGIN;
+
+SELECT plan(20);
+
+-- ── Schema: notifications ──────────────────────────────────────────────────────
+SELECT has_table('public', 'notifications', 'notifications table exists');
+
+SELECT has_column('public', 'notifications', 'id',         'notifications has id');
+SELECT has_column('public', 'notifications', 'tipo',       'notifications has tipo');
+SELECT has_column('public', 'notifications', 'conteudo',   'notifications has conteudo');
+SELECT has_column('public', 'notifications', 'status',     'notifications has status');
+SELECT has_column('public', 'notifications', 'created_at', 'notifications has created_at');
+
+SELECT col_not_null('public', 'notifications', 'tipo',       'notifications.tipo is NOT NULL');
+SELECT col_not_null('public', 'notifications', 'conteudo',   'notifications.conteudo is NOT NULL');
+SELECT col_not_null('public', 'notifications', 'status',     'notifications.status is NOT NULL');
+SELECT col_not_null('public', 'notifications', 'created_at', 'notifications.created_at is NOT NULL');
+
+SELECT col_default_is('public', 'notifications', 'status', 'unread',
+  'notifications.status defaults to unread');
+
+-- ── Index (RNF03 — listagem por status/data em ≤ 2s) ───────────────────────────
+SELECT ok(
+  EXISTS (SELECT 1 FROM pg_indexes
+          WHERE schemaname = 'public' AND tablename = 'notifications'
+            AND indexname = 'notifications_status_created_at_idx'),
+  'composite index on (status, created_at) exists'
+);
+
+-- ── RLS enabled ────────────────────────────────────────────────────────────────
+SELECT ok(
+  (SELECT relrowsecurity FROM pg_class
+   WHERE relname = 'notifications' AND relnamespace = 'public'::regnamespace),
+  'RLS is enabled on notifications'
+);
+
+-- ── Policy & privileges (RNF09 — admin-only) ───────────────────────────────────
+SELECT ok(
+  EXISTS (SELECT 1 FROM pg_policies
+          WHERE schemaname = 'public' AND tablename = 'notifications'
+            AND policyname = 'notifications_owner_all'),
+  'owner-only policy exists on notifications'
+);
+
+SELECT ok(NOT has_table_privilege('anon', 'public.notifications', 'SELECT'),
+  'anon has no SELECT on notifications');
+SELECT ok(NOT has_table_privilege('anon', 'public.notifications', 'INSERT'),
+  'anon has no INSERT on notifications');
+SELECT ok(has_table_privilege('authenticated', 'public.notifications', 'SELECT'),
+  'authenticated has SELECT on notifications');
+
+-- ── Constraints ────────────────────────────────────────────────────────────────
+SELECT throws_ok(
+  $$INSERT INTO public.notifications (tipo, conteudo, status)
+    VALUES ('novo_lead', 'Novo lead capturado', 'invalido')$$,
+  '23514',
+  NULL,
+  'invalid notifications.status rejected by CHECK constraint'
+);
+
+SELECT throws_ok(
+  $$INSERT INTO public.notifications (tipo, conteudo) VALUES ('', 'x')$$,
+  '23514',
+  NULL,
+  'empty notifications.tipo rejected by CHECK constraint'
+);
+
+-- default status applies on insert
+INSERT INTO public.notifications (tipo, conteudo)
+VALUES ('novo_lead', 'Novo lead capturado');
+
+SELECT is(
+  (SELECT status FROM public.notifications WHERE conteudo = 'Novo lead capturado'),
+  'unread',
+  'inserted notification defaults to status unread'
+);
+
+SELECT * FROM finish();
+ROLLBACK;


### PR DESCRIPTION
## Feature entregue

> Formato FDD: **[ação] [resultado] [objeto]**

Criar tabela de notificações com RLS admin-only no banco

| Campo | Valor |
|---|---|
| **CP** | CP9 — Sistema de Notificações no Sistema |
| **Iteração** | IT2 — Lead Capture |
| **Issue** | Closes #186 (sub-issue de schema da feature #179) |
| **Chief Programmer** | @HeitorM50 |

---

## O que foi implementado

- Migration `20260628000100_create_notifications.sql` criando a tabela `public.notifications` (`id`, `tipo`, `conteudo`, `status`, `created_at`).
- `status` modelado como `text` + `CHECK (status IN ('unread','read'))` com default `unread`, seguindo a convenção do repositório (`clients`/`leads`) em vez de `ENUM` nativo.
- RLS habilitado com policy **admin-only** `notifications_owner_all` (`app_metadata.role = 'owner'`), igual a `clients`/`client_cards` — atende RNF09.
- Índice composto `notifications_status_created_at_idx (status, created_at DESC)` para listagem performática (RNF03 — ≤ 2s).
- Grants no padrão do projeto: `service_role` full, `authenticated` gated pela policy, `anon` revogado.
- Teste pgTAP `notifications_test.sql` (20 asserts) cobrindo schema, NOT NULL, default, índice, RLS, policy, ausência de acesso `anon` e constraints.
- Bloco de exemplo (comentado) em `supabase/seed.sql`.

---

## DoD — Definition of Done

- [x] Critérios de aceite todos validados (Given/When/Then cobertos) — escopo da sub-issue de schema #186
- [x] Testes automatizados passando (unitários + integração onde há lógica de negócio) — `supabase test db` → **PASS**
- [x] Lint sem erros (ESLint + Prettier) — N/A: mudança 100% SQL, sem código JS/TS
- [x] CI verde (build + testes + lint)
- [x] Migration de banco aplicada em staging sem erros (se existir) — validada localmente via `supabase start`; staging pendente
- [ ] Validação parcial registrada pelo cliente na issue (ou agendada para próxima validação formal)
- [x] Documentação atualizada (README, ADR ou gh-pages) se necessário — N/A: sem mudança de contrato externo nesta sub-issue
- [x] Sem vulnerabilidades críticas abertas no SAST/linting de segurança — RLS habilitado e `anon` revogado

---

## Checklist de revisão (para o revisor)

- [x] Lógica de negócio correta segundo os critérios de aceitação da issue
- [x] Sem código morto ou TODO não rastreado
- [x] Nenhuma credencial, secret ou dado sensível exposto
- [x] Nomes de variáveis/funções seguem convenção do projeto

---

## Evidências

Execução local de `supabase test db` (stack local via `supabase start`):

```
/supabase/tests/clients_test.sql ........ ok
/supabase/tests/leads_test.sql .......... ok
/supabase/tests/notifications_test.sql .. ok
Result: PASS
```

Critérios de aceite da #186 cobertos pelos testes:
- Tabela `notifications` com RLS habilitado e policy admin-only de leitura/escrita ✔
- Índice composto `(status, created_at)` presente (RNF03) ✔

---

## Notas para o revisor

- **`status` como `text` + `CHECK`, não `ENUM` nativo**: a issue cita `ENUM['unread','read']`, mas a convenção atual do repo é `text` + `CHECK` (ver `clients.status`, `leads.status`); tipos enum nativos foram inclusive removidos na migration `20260529180000`. Mantém a semântica do enum seguindo o padrão do código.
- **Base do PR é `entrega-unidade4`** (não `main`), acompanhando o fluxo das demais features da unidade.
- Esta é a **sub-issue 1/3** da F07 (#179): entrega apenas o schema. As sub-issues seguintes (API e UI) e os RFs de listagem/alteração de status dependem desta tabela.

