### PR TITLE
fix(ci): conserta todo o CI da main (lint, typecheck, testes, prettier, grants de produtos)

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,17 @@
+# Subprojeto Docusaurus — possui estrutura/formatação próprias, não é checado
+# pelo Prettier da raiz (evita que ~77 docs bloqueiem o job de Lint da CI).
+gh-pages/
+
+# Dependências e artefatos gerados / build
+node_modules/
+**/dist/
+**/build/
+**/.svelte-kit/
+frontend/src/lib/paraglide/
+gh-pages/site/
+gh-pages/docusaurus/.docusaurus/
+
+# Ambiente / lockfiles
+.env
+.env.*
+package-lock.json

--- a/README.md
+++ b/README.md
@@ -19,7 +19,6 @@ Produto: **Crianex Hub** — plataforma administrativa centralizada e vitrine di
 - **Docs (Unidade 2):** [/unidade2](https://mdsreq-fga-unb.github.io/REQ-2026.1-T02-Crianex-/)
 - **Docs (Unidade 3):** [/unidade3](https://mdsreq-fga-unb.github.io/REQ-2026.1-T02-Crianex-/unidade3/)
 
-
 <p align="center">
   <img 
     src="https://capsule-render.vercel.app/api?type=rect&color=0:004d1a,50:800040,100:33001a&height=2&section=header"

--- a/backend/src/crm/crm-columns.routes.ts
+++ b/backend/src/crm/crm-columns.routes.ts
@@ -29,7 +29,8 @@ crmColumnsRouter.post('/', ...ownerGuard, async (req, res) => {
   const title = typeof req.body?.['title'] === 'string' ? req.body['title'] : '';
   const color = typeof req.body?.['color'] === 'string' ? req.body['color'] : undefined;
   const position = typeof req.body?.['position'] === 'number' ? req.body['position'] : undefined;
-  const entry_hint = typeof req.body?.['entry_hint'] === 'string' ? req.body['entry_hint'] : undefined;
+  const entry_hint =
+    typeof req.body?.['entry_hint'] === 'string' ? req.body['entry_hint'] : undefined;
   const exit_hint = typeof req.body?.['exit_hint'] === 'string' ? req.body['exit_hint'] : undefined;
 
   try {
@@ -56,7 +57,10 @@ crmColumnsRouter.post('/', ...ownerGuard, async (req, res) => {
 // PATCH /api/admin/crm/columns/reorder — reordena múltiplas colunas (RF40 · RNF22)
 crmColumnsRouter.patch('/reorder', ...ownerGuard, async (req, res) => {
   const order = req.body?.['order'];
-  if (!Array.isArray(order) || order.some((o) => typeof o.id !== 'string' || typeof o.position !== 'number')) {
+  if (
+    !Array.isArray(order) ||
+    order.some((o) => typeof o.id !== 'string' || typeof o.position !== 'number')
+  ) {
     res.status(400).json({ message: 'Body deve ser { order: [{id, position}] }.' });
     return;
   }

--- a/backend/src/crm/crm-columns.routes.ts
+++ b/backend/src/crm/crm-columns.routes.ts
@@ -33,7 +33,13 @@ crmColumnsRouter.post('/', ...ownerGuard, async (req, res) => {
   const exit_hint = typeof req.body?.['exit_hint'] === 'string' ? req.body['exit_hint'] : undefined;
 
   try {
-    const column = await createColumn({ title, color, position, entry_hint, exit_hint });
+    const column = await createColumn({
+      title,
+      ...(color !== undefined && { color }),
+      ...(position !== undefined && { position }),
+      ...(entry_hint !== undefined && { entry_hint }),
+      ...(exit_hint !== undefined && { exit_hint }),
+    });
     res.status(201).json(column);
   } catch (err) {
     if (err instanceof CrmColumnError) {

--- a/backend/src/crm/crm-columns.service.ts
+++ b/backend/src/crm/crm-columns.service.ts
@@ -22,7 +22,8 @@ export class CrmColumnError extends Error {
   }
 }
 
-const SELECT = 'id, title, color, position, is_default, entry_hint, exit_hint, created_at, updated_at';
+const SELECT =
+  'id, title, color, position, is_default, entry_hint, exit_hint, created_at, updated_at';
 
 const COLOR_RE = /^#[0-9a-fA-F]{6}$/;
 
@@ -48,7 +49,8 @@ export async function createColumn(input: {
   if (!title) throw new CrmColumnError('Título da coluna é obrigatório.', 'INVALID_TITLE');
 
   const color = input.color ?? '#7f3fe5';
-  if (!COLOR_RE.test(color)) throw new CrmColumnError('Cor inválida. Use formato hex #RRGGBB.', 'INVALID_COLOR');
+  if (!COLOR_RE.test(color))
+    throw new CrmColumnError('Cor inválida. Use formato hex #RRGGBB.', 'INVALID_COLOR');
 
   const supabase = getSupabaseClient();
 
@@ -59,7 +61,7 @@ export async function createColumn(input: {
     .limit(1)
     .maybeSingle();
 
-  const position = input.position ?? ((maxRow?.position ?? -1) + 1);
+  const position = input.position ?? (maxRow?.position ?? -1) + 1;
 
   const { data, error } = await supabase
     .from('crm_columns')
@@ -122,9 +124,7 @@ export async function reorderColumns(order: { id: string; position: number }[]):
   if (!order.length) return;
   const supabase = getSupabaseClient();
   await Promise.all(
-    order.map(({ id, position }) =>
-      supabase.from('crm_columns').update({ position }).eq('id', id)
-    )
+    order.map(({ id, position }) => supabase.from('crm_columns').update({ position }).eq('id', id))
   );
 }
 
@@ -149,15 +149,10 @@ export async function deleteColumn(id: string): Promise<void> {
   }
 
   // Enforce ≥1 column invariant
-  const { count } = await supabase
-    .from('crm_columns')
-    .select('*', { count: 'exact', head: true });
+  const { count } = await supabase.from('crm_columns').select('*', { count: 'exact', head: true });
 
   if ((count ?? 0) <= 1) {
-    throw new CrmColumnError(
-      'O funil precisa ter ao menos uma coluna.',
-      'LAST_COLUMN'
-    );
+    throw new CrmColumnError('O funil precisa ter ao menos uma coluna.', 'LAST_COLUMN');
   }
 
   // Verify no cards remain in this column before deleting.

--- a/backend/src/lib/supabase.ts
+++ b/backend/src/lib/supabase.ts
@@ -303,7 +303,7 @@ if (isProduction) {
     const controller = new AbortController();
     const timeout = setTimeout(() => controller.abort(), 2000);
 
-    const res = await fetch(url, { method: 'GET', signal: controller.signal });
+    await fetch(url, { method: 'GET', signal: controller.signal });
     clearTimeout(timeout);
 
     // Any HTTP response (including 404) means the server is reachable.

--- a/backend/tests/database/crm_columns.test.ts
+++ b/backend/tests/database/crm_columns.test.ts
@@ -6,7 +6,8 @@ import { describe, expect, it } from 'vitest';
 const migrationsDir = resolve(import.meta.dirname, '../../../supabase/migrations');
 
 // Whitespace é normalizado para que os asserts não dependam do alinhamento das colunas.
-const norm = (path: string) => readFileSync(resolve(migrationsDir, path), 'utf8').replace(/\s+/g, ' ');
+const norm = (path: string) =>
+  readFileSync(resolve(migrationsDir, path), 'utf8').replace(/\s+/g, ' ');
 
 const tableSql = norm('20260625000100_create_crm_columns.sql');
 const seedSql = norm('20260625000200_seed_crm_default_column.sql');

--- a/backend/tests/database/crm_columns.test.ts
+++ b/backend/tests/database/crm_columns.test.ts
@@ -3,49 +3,39 @@ import { resolve } from 'node:path';
 
 import { describe, expect, it } from 'vitest';
 
-const migrationPath = resolve(
-  import.meta.dirname,
-  '../../../supabase/migrations/20260622000100_create_crm_columns_table.sql'
-);
+const migrationsDir = resolve(import.meta.dirname, '../../../supabase/migrations');
 
-const migrationSql = readFileSync(migrationPath, 'utf8');
+// Whitespace é normalizado para que os asserts não dependam do alinhamento das colunas.
+const norm = (path: string) => readFileSync(resolve(migrationsDir, path), 'utf8').replace(/\s+/g, ' ');
+
+const tableSql = norm('20260625000100_create_crm_columns.sql');
+const seedSql = norm('20260625000200_seed_crm_default_column.sql');
 
 describe('crm_columns migration', () => {
   it('cria a tabela crm_columns com as colunas obrigatórias', () => {
-    expect(migrationSql).toContain('create table public.crm_columns');
-    expect(migrationSql).toContain('nome text not null');
-    expect(migrationSql).toContain('ordem integer not null');
-    expect(migrationSql).toContain('is_default boolean default false not null');
-    expect(migrationSql).toContain('created_at timestamp with time zone');
+    expect(tableSql).toContain('CREATE TABLE IF NOT EXISTS public.crm_columns');
+    expect(tableSql).toContain('title text NOT NULL');
+    expect(tableSql).toContain('position integer NOT NULL DEFAULT 0');
+    expect(tableSql).toContain('is_default boolean NOT NULL DEFAULT false');
+    expect(tableSql).toContain('created_at timestamptz NOT NULL DEFAULT now()');
   });
 
   it('garante no máximo 1 coluna default via índice único parcial', () => {
-    expect(migrationSql).toContain('create unique index crm_columns_single_default_idx');
-    expect(migrationSql).toContain('on public.crm_columns (is_default)');
-    expect(migrationSql).toContain('where is_default = true');
+    expect(tableSql).toContain('CREATE UNIQUE INDEX IF NOT EXISTS crm_columns_one_default_idx');
+    expect(tableSql).toContain('ON public.crm_columns (is_default)');
+    expect(tableSql).toContain('WHERE is_default = true');
   });
 
-  it('garante as invariantes de "≥1 coluna" e "exatamente 1 default" via trigger', () => {
-    expect(migrationSql).toContain('public.check_crm_columns_invariants()');
-    expect(migrationSql).toContain('deve existir ao menos 1 coluna');
-    expect(migrationSql).toContain('deve existir exatamente 1 coluna marcada como is_default');
-    expect(migrationSql).toContain('create constraint trigger crm_columns_invariants_on_update');
-    expect(migrationSql).toContain('create constraint trigger crm_columns_invariants_on_delete');
-    expect(migrationSql).toContain('deferrable initially immediate');
-  });
-
-  it('habilita RLS com policy admin-only e revoga acesso de anon', () => {
-    expect(migrationSql).toContain('alter table public.crm_columns enable row level security');
-    expect(migrationSql).toContain(
-      'Permitir leitura e gerenciamento de colunas do CRM para owners'
-    );
-    expect(migrationSql).toContain('using (public.is_owner(auth.uid()))');
-    expect(migrationSql).toContain('with check (public.is_owner(auth.uid()))');
-    expect(migrationSql).toContain('revoke all on table public.crm_columns from anon');
+  it('habilita RLS com policy admin-only (owner via JWT)', () => {
+    expect(tableSql).toContain('ALTER TABLE public.crm_columns ENABLE ROW LEVEL SECURITY');
+    expect(tableSql).toContain('CREATE POLICY "crm_columns_owner_all" ON public.crm_columns');
+    expect(tableSql).toContain("'app_metadata' ->> 'role' = 'owner'");
   });
 
   it('faz seed inicial garantindo ao menos 1 coluna default', () => {
-    expect(migrationSql).toContain('insert into public.crm_columns (nome, ordem, is_default)');
-    expect(migrationSql).toContain("('Novo Lead', 1, true)");
+    expect(seedSql).toContain('INSERT INTO public.crm_columns');
+    expect(seedSql).toContain("('Novo Lead',");
+    // Só insere quando a tabela está vazia — mantém a invariante de ≥1 default.
+    expect(seedSql).toContain('WHERE NOT EXISTS (SELECT 1 FROM public.crm_columns)');
   });
 });

--- a/frontend/src/routes/(admin)/admin/crm/+page.svelte
+++ b/frontend/src/routes/(admin)/admin/crm/+page.svelte
@@ -4,12 +4,27 @@
   import { onMount } from 'svelte';
 
   type CrmColumn = {
-    id: string; title: string; color: string; position: number;
-    is_default: boolean; entry_hint: string | null; exit_hint: string | null;
-    created_at: string; updated_at: string;
+    id: string;
+    title: string;
+    color: string;
+    position: number;
+    is_default: boolean;
+    entry_hint: string | null;
+    exit_hint: string | null;
+    created_at: string;
+    updated_at: string;
   };
 
-  const COL_COLORS = ['#7f3fe5','#e71f84','#66df7a','#3b82f6','#f59e0b','#06b6d4','#ec4899','#9a968e'];
+  const COL_COLORS = [
+    '#7f3fe5',
+    '#e71f84',
+    '#66df7a',
+    '#3b82f6',
+    '#f59e0b',
+    '#06b6d4',
+    '#ec4899',
+    '#9a968e',
+  ];
 
   let { data } = $props<{ data: { columns: CrmColumn[]; error?: string; forbidden?: boolean } }>();
 
@@ -39,34 +54,49 @@
 
   // ── Column editor ──
   function openEditor() {
-    editCols = columns.map(c => ({ ...c }));
+    editCols = columns.map((c) => ({ ...c }));
     editingCols = true;
   }
   function editorUpd(id: string, patch: Partial<CrmColumn>) {
-    editCols = editCols.map(c => c.id === id ? { ...c, ...patch } : c);
+    editCols = editCols.map((c) => (c.id === id ? { ...c, ...patch } : c));
   }
   function editorAdd() {
-    editCols = [...editCols, {
-      id: `col-${Date.now()}`, title: 'Nova coluna',
-      color: COL_COLORS[editCols.length % COL_COLORS.length],
-      position: editCols.length, is_default: false,
-      entry_hint: '', exit_hint: '', created_at: '', updated_at: '', _new: true
-    }];
+    editCols = [
+      ...editCols,
+      {
+        id: `col-${Date.now()}`,
+        title: 'Nova coluna',
+        color: COL_COLORS[editCols.length % COL_COLORS.length],
+        position: editCols.length,
+        is_default: false,
+        entry_hint: '',
+        exit_hint: '',
+        created_at: '',
+        updated_at: '',
+        _new: true,
+      },
+    ];
   }
   function editorDel(id: string) {
     if (editCols.length <= 1) return;
-    if (editCols.find(c => c.id === id)?.is_default) return;
-    editCols = editCols.filter(c => c.id !== id);
+    if (editCols.find((c) => c.id === id)?.is_default) return;
+    editCols = editCols.filter((c) => c.id !== id);
   }
   function editorDrop(targetId: string) {
-    if (!colDragId || colDragId === targetId) { colDragId = null; colDropTarget = null; return; }
+    if (!colDragId || colDragId === targetId) {
+      colDragId = null;
+      colDropTarget = null;
+      return;
+    }
     const next = [...editCols];
-    const from = next.findIndex(c => c.id === colDragId);
+    const from = next.findIndex((c) => c.id === colDragId);
     const [moved] = next.splice(from, 1);
-    let to = next.findIndex(c => c.id === targetId);
+    let to = next.findIndex((c) => c.id === targetId);
     if (colDropTarget?.after) to += 1;
     next.splice(to, 0, moved);
-    editCols = next; colDragId = null; colDropTarget = null;
+    editCols = next;
+    colDragId = null;
+    colDropTarget = null;
   }
 
   // ── Single-column quick editor (gear button on the card) ──
@@ -84,16 +114,21 @@
       quickError = 'Informe um nome para a coluna.';
       return;
     }
-    quickSaving = true; quickError = '';
+    quickSaving = true;
+    quickError = '';
     try {
       const updated = await apiFetch<CrmColumn>(`/admin/crm/columns/${quickCol.id}`, {
         method: 'PATCH',
         body: JSON.stringify({
-          title: quickCol.title, color: quickCol.color,
-          entry_hint: quickCol.entry_hint, exit_hint: quickCol.exit_hint,
+          title: quickCol.title,
+          color: quickCol.color,
+          entry_hint: quickCol.entry_hint,
+          exit_hint: quickCol.exit_hint,
         }),
       });
-      columns = columns.map(c => c.id === updated.id ? updated : c).sort((a, b) => a.position - b.position);
+      columns = columns
+        .map((c) => (c.id === updated.id ? updated : c))
+        .sort((a, b) => a.position - b.position);
       quickCol = null;
     } catch (err) {
       const e = err as { status?: number; message?: string };
@@ -104,36 +139,40 @@
   }
   async function deleteQuickColumn() {
     if (!quickCol || quickCol.is_default) return;
-    quickSaving = true; quickError = '';
+    quickSaving = true;
+    quickError = '';
     try {
       await apiFetch<void>(`/admin/crm/columns/${quickCol.id}`, { method: 'DELETE' });
-      columns = columns.filter(c => c.id !== quickCol!.id);
+      columns = columns.filter((c) => c.id !== quickCol!.id);
       quickCol = null;
     } catch (err) {
       const e = err as { status?: number; message?: string };
-      quickError = e.status === 409
-        ? (e.message || 'Não é possível remover esta coluna. Verifique se há leads vinculados ou se é a coluna padrão.')
-        : (e.message || 'Erro ao remover coluna.');
+      quickError =
+        e.status === 409
+          ? e.message ||
+            'Não é possível remover esta coluna. Verifique se há leads vinculados ou se é a coluna padrão.'
+          : e.message || 'Erro ao remover coluna.';
     } finally {
       quickSaving = false;
     }
   }
 
   async function saveColumns() {
-    const empty = editCols.filter(c => !c.title.trim());
+    const empty = editCols.filter((c) => !c.title.trim());
     if (empty.length) {
-      invalidColIds = new Set(empty.map(c => c.id));
+      invalidColIds = new Set(empty.map((c) => c.id));
       colsError = 'Toda coluna precisa de um nome. Preencha os campos destacados.';
       return;
     }
     invalidColIds = new Set();
-    colSaving = true; colsError = '';
+    colSaving = true;
+    colsError = '';
     try {
-      const originalIds = new Set(columns.map(c => c.id));
-      const newIds = new Set(editCols.map(c => c.id));
+      const originalIds = new Set(columns.map((c) => c.id));
+      const newIds = new Set(editCols.map((c) => c.id));
 
       // Delete removed columns
-      for (const col of columns.filter(c => !newIds.has(c.id))) {
+      for (const col of columns.filter((c) => !newIds.has(c.id))) {
         await apiFetch<void>(`/admin/crm/columns/${col.id}`, { method: 'DELETE' });
       }
 
@@ -145,16 +184,33 @@
         if (!originalIds.has(col.id)) {
           const created = await apiFetch<CrmColumn>('/admin/crm/columns', {
             method: 'POST',
-            body: JSON.stringify({ title: col.title, color: col.color, position: pos, entry_hint: col.entry_hint, exit_hint: col.exit_hint }),
+            body: JSON.stringify({
+              title: col.title,
+              color: col.color,
+              position: pos,
+              entry_hint: col.entry_hint,
+              exit_hint: col.exit_hint,
+            }),
           });
           saved.push(created);
         } else {
-          const orig = columns.find(c => c.id === col.id)!;
-          const changed = col.title !== orig.title || col.color !== orig.color || col.entry_hint !== orig.entry_hint || col.exit_hint !== orig.exit_hint || pos !== orig.position;
+          const orig = columns.find((c) => c.id === col.id)!;
+          const changed =
+            col.title !== orig.title ||
+            col.color !== orig.color ||
+            col.entry_hint !== orig.entry_hint ||
+            col.exit_hint !== orig.exit_hint ||
+            pos !== orig.position;
           if (changed) {
             const updated = await apiFetch<CrmColumn>(`/admin/crm/columns/${col.id}`, {
               method: 'PATCH',
-              body: JSON.stringify({ title: col.title, color: col.color, position: pos, entry_hint: col.entry_hint, exit_hint: col.exit_hint }),
+              body: JSON.stringify({
+                title: col.title,
+                color: col.color,
+                position: pos,
+                entry_hint: col.entry_hint,
+                exit_hint: col.exit_hint,
+              }),
             });
             saved.push(updated);
           } else {
@@ -167,9 +223,11 @@
       editingCols = false;
     } catch (err) {
       const e = err as { status?: number; message?: string };
-      colsError = e.status === 409
-        ? (e.message || 'Não é possível remover esta coluna. Verifique se há leads vinculados ou se é a coluna padrão.')
-        : (e.message || 'Erro ao salvar colunas.');
+      colsError =
+        e.status === 409
+          ? e.message ||
+            'Não é possível remover esta coluna. Verifique se há leads vinculados ou se é a coluna padrão.'
+          : e.message || 'Erro ao salvar colunas.';
     } finally {
       colSaving = false;
     }
@@ -180,7 +238,9 @@
       colsLoading = true;
       const fresh = await apiFetch<CrmColumn[]>('/admin/crm/columns');
       if (fresh?.length) columns = fresh.sort((a, b) => a.position - b.position);
-    } catch { /* keep server-loaded data */ } finally {
+    } catch {
+      /* keep server-loaded data */
+    } finally {
       colsLoading = false;
     }
   });
@@ -193,7 +253,7 @@
     <span class="crm-crumb">/ {columns.length} {columns.length === 1 ? 'coluna' : 'colunas'}</span>
     <span class="grow"></span>
     <button class="btn sm" onclick={openEditor}>
-      <Settings size={13}/> Personalizar colunas
+      <Settings size={13} /> Personalizar colunas
     </button>
   </div>
 
@@ -203,15 +263,15 @@
       <div class="crm-loading">Carregando colunas…</div>
     {:else if data.forbidden}
       <div class="crm-empty-state">
-        <div class="ico"><Settings size={18}/></div>
+        <div class="ico"><Settings size={18} /></div>
         Acesso restrito — apenas administradores podem gerenciar o CRM.
       </div>
     {:else if columns.length === 0}
       <div class="crm-empty-state">
-        <div class="ico"><Settings size={18}/></div>
+        <div class="ico"><Settings size={18} /></div>
         Nenhuma coluna configurada.
         <button class="btn sm" style="margin-top:12px" onclick={openEditor}>
-          <Plus size={13}/> Configurar pipeline
+          <Plus size={13} /> Configurar pipeline
         </button>
       </div>
     {:else}
@@ -224,7 +284,7 @@
               {#if col.is_default}<span class="default-badge">padrão</span>{/if}
               <span class="ct">0</span>
               <button class="gear" title="Editar coluna" onclick={() => openQuickEditor(col)}>
-                <Settings size={12}/>
+                <Settings size={12} />
               </button>
             </div>
             <div class="crm-col-empty">
@@ -232,9 +292,7 @@
             </div>
           </div>
         {/each}
-        <button class="crm-addcol" onclick={openEditor} title="Adicionar coluna">
-          + COLUNA
-        </button>
+        <button class="crm-addcol" onclick={openEditor} title="Adicionar coluna"> + COLUNA </button>
       </div>
     {/if}
   </div>
@@ -242,12 +300,20 @@
 
 <!-- ── Column Editor Modal ── -->
 {#if editingCols}
-  <div class="admin-overlay" role="presentation" onclick={() => editingCols = false}>
-    <div class="admin-modal wide" role="dialog" aria-modal="true" aria-label="Editar colunas do pipeline" tabindex="-1" onclick={(e) => e.stopPropagation()} onkeydown={(e) => e.stopPropagation()}>
+  <div class="admin-overlay" role="presentation" onclick={() => (editingCols = false)}>
+    <div
+      class="admin-modal wide"
+      role="dialog"
+      aria-modal="true"
+      aria-label="Editar colunas do pipeline"
+      tabindex="-1"
+      onclick={(e) => e.stopPropagation()}
+      onkeydown={(e) => e.stopPropagation()}
+    >
       <div class="admin-modal-head">
         <h3>Editar colunas do pipeline</h3>
         <span class="crumbs">/ crm / colunas</span>
-        <button class="x" onclick={() => editingCols = false}><X size={13}/></button>
+        <button class="x" onclick={() => (editingCols = false)}><X size={13} /></button>
       </div>
       <div class="admin-modal-body">
         {#if colsError}
@@ -255,41 +321,90 @@
         {/if}
         <div class="crm-coleditor" role="list" ondragover={(e) => e.preventDefault()}>
           {#each editCols as c (c.id)}
-            <div class="crm-colrow {colDragId === c.id ? 'dragging' : ''} {colDropTarget?.id === c.id ? (colDropTarget?.after ? 'drop-after' : 'drop-before') : ''}"
+            <div
+              class="crm-colrow {colDragId === c.id ? 'dragging' : ''} {colDropTarget?.id === c.id
+                ? colDropTarget?.after
+                  ? 'drop-after'
+                  : 'drop-before'
+                : ''}"
               role="listitem"
-              ondragover={(e) => { e.preventDefault(); if (colDragId && colDragId !== c.id) { const r = e.currentTarget.getBoundingClientRect(); colDropTarget = { id: c.id, after: e.clientY > r.top + r.height / 2 }; } }}
-              ondrop={(e) => { e.preventDefault(); editorDrop(c.id); }}>
+              ondragover={(e) => {
+                e.preventDefault();
+                if (colDragId && colDragId !== c.id) {
+                  const r = e.currentTarget.getBoundingClientRect();
+                  colDropTarget = { id: c.id, after: e.clientY > r.top + r.height / 2 };
+                }
+              }}
+              ondrop={(e) => {
+                e.preventDefault();
+                editorDrop(c.id);
+              }}
+            >
               <div class="r1">
-                <span class="handle" draggable="true" role="button" tabindex="0" aria-label="Arraste para reordenar a coluna"
-                  ondragstart={() => colDragId = c.id}
-                  ondragend={() => { colDragId = null; colDropTarget = null; }}
-                  title="arraste para reordenar">
-                  <MoreVertical size={13}/><MoreVertical size={13} style="margin-left:-9px"/>
+                <span
+                  class="handle"
+                  draggable="true"
+                  role="button"
+                  tabindex="0"
+                  aria-label="Arraste para reordenar a coluna"
+                  ondragstart={() => (colDragId = c.id)}
+                  ondragend={() => {
+                    colDragId = null;
+                    colDropTarget = null;
+                  }}
+                  title="arraste para reordenar"
+                >
+                  <MoreVertical size={13} /><MoreVertical size={13} style="margin-left:-9px" />
                 </span>
-                <input class="cname {invalidColIds.has(c.id) ? 'invalid' : ''}" bind:value={c.title}
-                  oninput={() => { if (c.title.trim() && invalidColIds.has(c.id)) { invalidColIds = new Set([...invalidColIds].filter(id => id !== c.id)); } }}/>
+                <input
+                  class="cname {invalidColIds.has(c.id) ? 'invalid' : ''}"
+                  bind:value={c.title}
+                  oninput={() => {
+                    if (c.title.trim() && invalidColIds.has(c.id)) {
+                      invalidColIds = new Set([...invalidColIds].filter((id) => id !== c.id));
+                    }
+                  }}
+                />
                 <div class="crm-swatches">
                   {#each COL_COLORS as col}
-                    <button type="button" class="crm-swatch {c.color === col ? 'on' : ''}" style="background:{col}" aria-label={`Cor ${col}`} onclick={() => editorUpd(c.id, { color: col })}></button>
+                    <button
+                      type="button"
+                      class="crm-swatch {c.color === col ? 'on' : ''}"
+                      style="background:{col}"
+                      aria-label={`Cor ${col}`}
+                      onclick={() => editorUpd(c.id, { color: col })}
+                    ></button>
                   {/each}
                 </div>
                 {#if c.is_default}
                   <span class="default-badge">padrão</span>
                 {/if}
-                <button class="del" onclick={() => editorDel(c.id)} title="Excluir coluna"
-                  disabled={editCols.length <= 1 || c.is_default}>
-                  <X size={14}/>
+                <button
+                  class="del"
+                  onclick={() => editorDel(c.id)}
+                  title="Excluir coluna"
+                  disabled={editCols.length <= 1 || c.is_default}
+                >
+                  <X size={14} />
                 </button>
               </div>
               <div class="crit">
                 <div class="f">
-                  <label>Critério de entrada
-                    <textarea bind:value={c.entry_hint} placeholder="Quando um lead entra nesta coluna?"></textarea>
+                  <label
+                    >Critério de entrada
+                    <textarea
+                      bind:value={c.entry_hint}
+                      placeholder="Quando um lead entra nesta coluna?"
+                    ></textarea>
                   </label>
                 </div>
                 <div class="f">
-                  <label>Critério de saída
-                    <textarea bind:value={c.exit_hint} placeholder="Quando um lead sai desta coluna?"></textarea>
+                  <label
+                    >Critério de saída
+                    <textarea
+                      bind:value={c.exit_hint}
+                      placeholder="Quando um lead sai desta coluna?"
+                    ></textarea>
                   </label>
                 </div>
               </div>
@@ -301,12 +416,17 @@
         </div>
       </div>
       <div class="admin-modal-foot">
-        <span class="mono" style="font-size:10.5px;color:var(--text-faint);letter-spacing:0.06em;text-transform:uppercase;margin-right:auto">
+        <span
+          class="mono"
+          style="font-size:10.5px;color:var(--text-faint);letter-spacing:0.06em;text-transform:uppercase;margin-right:auto"
+        >
           arraste pelo ⠿ para reordenar
         </span>
-        <button class="btn ghost sm" onclick={() => editingCols = false} disabled={colSaving}>Cancelar</button>
+        <button class="btn ghost sm" onclick={() => (editingCols = false)} disabled={colSaving}
+          >Cancelar</button
+        >
         <button class="btn sm" onclick={saveColumns} disabled={colSaving}>
-          {#if colSaving}Salvando…{:else}Salvar pipeline <Check size={12}/>{/if}
+          {#if colSaving}Salvando…{:else}Salvar pipeline <Check size={12} />{/if}
         </button>
       </div>
     </div>
@@ -316,11 +436,19 @@
 <!-- ── Quick column editor (gear button on the card) ── -->
 {#if quickCol}
   <div class="admin-overlay" role="presentation" onclick={closeQuickEditor}>
-    <div class="admin-modal" role="dialog" aria-modal="true" aria-label="Editar coluna" tabindex="-1" onclick={(e) => e.stopPropagation()} onkeydown={(e) => e.stopPropagation()}>
+    <div
+      class="admin-modal"
+      role="dialog"
+      aria-modal="true"
+      aria-label="Editar coluna"
+      tabindex="-1"
+      onclick={(e) => e.stopPropagation()}
+      onkeydown={(e) => e.stopPropagation()}
+    >
       <div class="admin-modal-head">
         <h3>Editar coluna</h3>
         <span class="crumbs">/ crm / colunas / {quickCol.title}</span>
-        <button class="x" onclick={closeQuickEditor}><X size={13}/></button>
+        <button class="x" onclick={closeQuickEditor}><X size={13} /></button>
       </div>
       <div class="admin-modal-body">
         {#if quickError}
@@ -328,37 +456,61 @@
         {/if}
         <div class="crm-colrow">
           <div class="r1">
-            <input class="cname {!quickCol.title.trim() ? 'invalid' : ''}" bind:value={quickCol.title}/>
+            <input
+              class="cname {!quickCol.title.trim() ? 'invalid' : ''}"
+              bind:value={quickCol.title}
+            />
             <div class="crm-swatches">
               {#each COL_COLORS as col}
-                <button type="button" class="crm-swatch {quickCol.color === col ? 'on' : ''}" style="background:{col}" aria-label={`Cor ${col}`} onclick={() => quickCol = quickCol && { ...quickCol, color: col }}></button>
+                <button
+                  type="button"
+                  class="crm-swatch {quickCol.color === col ? 'on' : ''}"
+                  style="background:{col}"
+                  aria-label={`Cor ${col}`}
+                  onclick={() => (quickCol = quickCol && { ...quickCol, color: col })}
+                ></button>
               {/each}
             </div>
             {#if quickCol.is_default}
               <span class="default-badge">padrão</span>
             {/if}
-            <button class="del" onclick={deleteQuickColumn} title="Excluir coluna" disabled={quickCol.is_default || quickSaving}>
-              <X size={14}/>
+            <button
+              class="del"
+              onclick={deleteQuickColumn}
+              title="Excluir coluna"
+              disabled={quickCol.is_default || quickSaving}
+            >
+              <X size={14} />
             </button>
           </div>
           <div class="crit">
             <div class="f">
-              <label>Critério de entrada
-                <textarea bind:value={quickCol.entry_hint} placeholder="Quando um lead entra nesta coluna?"></textarea>
+              <label
+                >Critério de entrada
+                <textarea
+                  bind:value={quickCol.entry_hint}
+                  placeholder="Quando um lead entra nesta coluna?"
+                ></textarea>
               </label>
             </div>
             <div class="f">
-              <label>Critério de saída
-                <textarea bind:value={quickCol.exit_hint} placeholder="Quando um lead sai desta coluna?"></textarea>
+              <label
+                >Critério de saída
+                <textarea
+                  bind:value={quickCol.exit_hint}
+                  placeholder="Quando um lead sai desta coluna?"
+                ></textarea>
               </label>
             </div>
           </div>
         </div>
       </div>
       <div class="admin-modal-foot">
-        <button class="btn ghost sm" onclick={closeQuickEditor} disabled={quickSaving}>Cancelar</button>
+        <button class="btn ghost sm" onclick={closeQuickEditor} disabled={quickSaving}
+          >Cancelar</button
+        >
         <button class="btn sm" onclick={saveQuickColumn} disabled={quickSaving}>
-          {#if quickSaving}Salvando…{:else}Salvar <Check size={12}/>{/if}
+          {#if quickSaving}Salvando…{:else}Salvar <Check size={12} />{/if}
         </button>
       </div>
     </div>
@@ -371,135 +523,338 @@
     flex: 1;
     min-height: 0;
     min-width: 0;
-    display: flex; flex-direction: column;
-    background: var(--bg); color: var(--text); overflow: hidden;
+    display: flex;
+    flex-direction: column;
+    background: var(--bg);
+    color: var(--text);
+    overflow: hidden;
   }
   .crm-head {
-    display: flex; align-items: center; gap: 10px;
-    padding: 12px 20px; border-bottom: 1px solid var(--line);
-    background: var(--bg-elev); flex-shrink: 0; flex-wrap: wrap;
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    padding: 12px 20px;
+    border-bottom: 1px solid var(--line);
+    background: var(--bg-elev);
+    flex-shrink: 0;
+    flex-wrap: wrap;
   }
-  .crm-title { font-size: 13.5px; font-weight: 600; letter-spacing: -0.01em; }
-  .crm-crumb { font-family: var(--font-mono); font-size: 11px; color: var(--text-faint); }
-  .grow { flex: 1; }
+  .crm-title {
+    font-size: 13.5px;
+    font-weight: 600;
+    letter-spacing: -0.01em;
+  }
+  .crm-crumb {
+    font-family: var(--font-mono);
+    font-size: 11px;
+    color: var(--text-faint);
+  }
+  .grow {
+    flex: 1;
+  }
 
   /* ── Body ── */
-  .crm-body { flex: 1; min-width: 0; overflow: auto; padding: 16px 20px 28px; }
+  .crm-body {
+    flex: 1;
+    min-width: 0;
+    overflow: auto;
+    padding: 16px 20px 28px;
+  }
 
   /* ── Empty / loading states ── */
   .crm-loading {
-    padding: 60px 20px; text-align: center;
-    font-family: var(--font-mono); font-size: 12px; color: var(--text-faint);
+    padding: 60px 20px;
+    text-align: center;
+    font-family: var(--font-mono);
+    font-size: 12px;
+    color: var(--text-faint);
   }
   .crm-empty-state {
-    display: flex; flex-direction: column; align-items: center;
-    padding: 80px 20px; text-align: center;
-    font-size: 13px; color: var(--text-muted);
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    padding: 80px 20px;
+    text-align: center;
+    font-size: 13px;
+    color: var(--text-muted);
   }
   .crm-empty-state .ico {
-    width: 44px; height: 44px; border-radius: 12px;
-    display: grid; place-items: center;
-    background: var(--bg-soft); border: 1px solid var(--line);
-    margin: 0 auto 12px; color: var(--text-faint);
+    width: 44px;
+    height: 44px;
+    border-radius: 12px;
+    display: grid;
+    place-items: center;
+    background: var(--bg-soft);
+    border: 1px solid var(--line);
+    margin: 0 auto 12px;
+    color: var(--text-faint);
   }
 
   /* ── Kanban ── */
-  .crm-kanban { display: flex; gap: 12px; align-items: flex-start; min-height: 100%; }
+  .crm-kanban {
+    display: flex;
+    gap: 12px;
+    align-items: flex-start;
+    min-height: 100%;
+  }
   .crm-col {
-    flex: 0 0 260px; background: var(--bg-soft); border-radius: 12px;
-    padding: 10px; display: flex; flex-direction: column; gap: 8px;
+    flex: 0 0 260px;
+    background: var(--bg-soft);
+    border-radius: 12px;
+    padding: 10px;
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
     border: 1px solid var(--line);
   }
-  .crm-col-head { display: flex; align-items: center; gap: 8px; padding: 4px 4px 2px; }
-  .crm-col-head .dot { width: 9px; height: 9px; border-radius: 50%; flex-shrink: 0; }
-  .crm-col-head .title { font-size: 13px; font-weight: 600; letter-spacing: -0.01em; flex: 1; }
+  .crm-col-head {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    padding: 4px 4px 2px;
+  }
+  .crm-col-head .dot {
+    width: 9px;
+    height: 9px;
+    border-radius: 50%;
+    flex-shrink: 0;
+  }
+  .crm-col-head .title {
+    font-size: 13px;
+    font-weight: 600;
+    letter-spacing: -0.01em;
+    flex: 1;
+  }
   .crm-col-head .ct {
-    font-family: var(--font-mono); font-size: 10px; color: var(--text-faint);
-    background: var(--bg-elev); border: 1px solid var(--line);
-    padding: 1px 6px; border-radius: 100px;
+    font-family: var(--font-mono);
+    font-size: 10px;
+    color: var(--text-faint);
+    background: var(--bg-elev);
+    border: 1px solid var(--line);
+    padding: 1px 6px;
+    border-radius: 100px;
   }
   .crm-col-head .gear {
-    background: transparent; border: 0; color: var(--text-faint);
-    cursor: pointer; padding: 3px; border-radius: 6px; display: grid; place-items: center;
+    background: transparent;
+    border: 0;
+    color: var(--text-faint);
+    cursor: pointer;
+    padding: 3px;
+    border-radius: 6px;
+    display: grid;
+    place-items: center;
   }
-  .crm-col-head .gear:hover { color: var(--text); background: var(--bg-elev); }
+  .crm-col-head .gear:hover {
+    color: var(--text);
+    background: var(--bg-elev);
+  }
   .default-badge {
-    font-family: var(--font-mono); font-size: 9px; letter-spacing: 0.06em;
-    text-transform: uppercase; color: var(--purple);
-    background: var(--accent-soft); border: 1px solid var(--accent-line);
-    padding: 1px 6px; border-radius: 100px;
+    font-family: var(--font-mono);
+    font-size: 9px;
+    letter-spacing: 0.06em;
+    text-transform: uppercase;
+    color: var(--purple);
+    background: var(--accent-soft);
+    border: 1px solid var(--accent-line);
+    padding: 1px 6px;
+    border-radius: 100px;
   }
   .crm-col-empty {
-    border: 1px dashed var(--line); border-radius: 9px; padding: 22px 10px;
-    text-align: center; font-size: 11.5px; color: var(--text-faint);
+    border: 1px dashed var(--line);
+    border-radius: 9px;
+    padding: 22px 10px;
+    text-align: center;
+    font-size: 11.5px;
+    color: var(--text-faint);
     font-family: var(--font-mono);
   }
   .crm-addcol {
-    flex: 0 0 52px; align-self: stretch; min-height: 80px;
-    background: transparent; border: 1px dashed var(--line-strong);
-    border-radius: 12px; color: var(--text-faint); cursor: pointer;
-    display: grid; place-items: center; font-family: var(--font-mono);
-    font-size: 11px; writing-mode: vertical-rl; letter-spacing: 0.1em;
-    transition: color 0.12s, border-color 0.12s;
+    flex: 0 0 52px;
+    align-self: stretch;
+    min-height: 80px;
+    background: transparent;
+    border: 1px dashed var(--line-strong);
+    border-radius: 12px;
+    color: var(--text-faint);
+    cursor: pointer;
+    display: grid;
+    place-items: center;
+    font-family: var(--font-mono);
+    font-size: 11px;
+    writing-mode: vertical-rl;
+    letter-spacing: 0.1em;
+    transition:
+      color 0.12s,
+      border-color 0.12s;
   }
-  .crm-addcol:hover { color: var(--text); border-color: var(--purple); }
+  .crm-addcol:hover {
+    color: var(--text);
+    border-color: var(--purple);
+  }
   .crm-addcard {
-    background: transparent; border: 1px dashed var(--line-strong);
-    border-radius: 9px; color: var(--text-faint);
-    font-family: inherit; font-size: 12px; cursor: pointer;
-    transition: color 0.12s, border-color 0.12s; width: 100%;
+    background: transparent;
+    border: 1px dashed var(--line-strong);
+    border-radius: 9px;
+    color: var(--text-faint);
+    font-family: inherit;
+    font-size: 12px;
+    cursor: pointer;
+    transition:
+      color 0.12s,
+      border-color 0.12s;
+    width: 100%;
   }
-  .crm-addcard:hover { color: var(--text); border-color: var(--purple); }
+  .crm-addcard:hover {
+    color: var(--text);
+    border-color: var(--purple);
+  }
 
   /* ── Column editor ── */
-  .crm-coleditor { display: flex; flex-direction: column; gap: 10px; }
+  .crm-coleditor {
+    display: flex;
+    flex-direction: column;
+    gap: 10px;
+  }
   .crm-colrow {
-    display: flex; flex-direction: column; gap: 10px;
-    background: var(--bg-soft); border: 1px solid var(--line);
-    border-radius: 10px; padding: 12px; transition: border-color 0.12s, box-shadow 0.12s;
+    display: flex;
+    flex-direction: column;
+    gap: 10px;
+    background: var(--bg-soft);
+    border: 1px solid var(--line);
+    border-radius: 10px;
+    padding: 12px;
+    transition:
+      border-color 0.12s,
+      box-shadow 0.12s;
   }
-  .crm-colrow.dragging { opacity: 0.4; }
-  .crm-colrow.drop-before { box-shadow: 0 -3px 0 var(--purple); }
-  .crm-colrow.drop-after { box-shadow: 0 3px 0 var(--purple); }
-  .crm-colrow .r1 { display: flex; align-items: center; gap: 9px; }
-  .crm-colrow .handle { color: var(--text-faint); cursor: grab; display: inline-flex; }
+  .crm-colrow.dragging {
+    opacity: 0.4;
+  }
+  .crm-colrow.drop-before {
+    box-shadow: 0 -3px 0 var(--purple);
+  }
+  .crm-colrow.drop-after {
+    box-shadow: 0 3px 0 var(--purple);
+  }
+  .crm-colrow .r1 {
+    display: flex;
+    align-items: center;
+    gap: 9px;
+  }
+  .crm-colrow .handle {
+    color: var(--text-faint);
+    cursor: grab;
+    display: inline-flex;
+  }
   .crm-colrow input.cname {
-    flex: 1; background: var(--bg); border: 1px solid var(--line);
-    border-radius: 7px; padding: 7px 10px;
-    font-family: inherit; font-size: 13px; font-weight: 500; color: var(--text); outline: none;
+    flex: 1;
+    background: var(--bg);
+    border: 1px solid var(--line);
+    border-radius: 7px;
+    padding: 7px 10px;
+    font-family: inherit;
+    font-size: 13px;
+    font-weight: 500;
+    color: var(--text);
+    outline: none;
   }
-  .crm-colrow input.cname:focus { border-color: var(--purple); }
-  .crm-colrow input.cname.invalid { border-color: var(--pink); }
-  .crm-colrow .del { background: transparent; border: 0; color: var(--text-faint); cursor: pointer; padding: 5px; border-radius: 6px; }
-  .crm-colrow .del:hover:not(:disabled) { color: var(--pink); background: rgba(231,31,132,0.1); }
-  .crm-colrow .del:disabled { opacity: 0.3; cursor: not-allowed; }
-  .crm-swatches { display: flex; gap: 5px; }
-  .crm-swatch { width: 20px; height: 20px; border-radius: 5px; border: 2px solid transparent; cursor: pointer; padding: 0; }
-  .crm-swatch.on { border-color: var(--text); box-shadow: 0 0 0 2px var(--bg-soft); }
-  .crm-colrow .crit { display: grid; grid-template-columns: 1fr 1fr; gap: 8px; }
-  .crm-colrow .crit .f { display: flex; flex-direction: column; gap: 4px; }
+  .crm-colrow input.cname:focus {
+    border-color: var(--purple);
+  }
+  .crm-colrow input.cname.invalid {
+    border-color: var(--pink);
+  }
+  .crm-colrow .del {
+    background: transparent;
+    border: 0;
+    color: var(--text-faint);
+    cursor: pointer;
+    padding: 5px;
+    border-radius: 6px;
+  }
+  .crm-colrow .del:hover:not(:disabled) {
+    color: var(--pink);
+    background: rgba(231, 31, 132, 0.1);
+  }
+  .crm-colrow .del:disabled {
+    opacity: 0.3;
+    cursor: not-allowed;
+  }
+  .crm-swatches {
+    display: flex;
+    gap: 5px;
+  }
+  .crm-swatch {
+    width: 20px;
+    height: 20px;
+    border-radius: 5px;
+    border: 2px solid transparent;
+    cursor: pointer;
+    padding: 0;
+  }
+  .crm-swatch.on {
+    border-color: var(--text);
+    box-shadow: 0 0 0 2px var(--bg-soft);
+  }
+  .crm-colrow .crit {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 8px;
+  }
+  .crm-colrow .crit .f {
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+  }
   .crm-colrow .crit label {
-    font-family: var(--font-mono); font-size: 9px; letter-spacing: 0.08em;
-    text-transform: uppercase; color: var(--text-faint);
+    font-family: var(--font-mono);
+    font-size: 9px;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+    color: var(--text-faint);
   }
   .crm-colrow .crit textarea {
-    background: var(--bg); border: 1px solid var(--line); border-radius: 7px;
-    padding: 6px 9px; font-family: inherit; font-size: 12px; color: var(--text);
-    outline: none; resize: none; min-height: 44px; line-height: 1.4;
+    background: var(--bg);
+    border: 1px solid var(--line);
+    border-radius: 7px;
+    padding: 6px 9px;
+    font-family: inherit;
+    font-size: 12px;
+    color: var(--text);
+    outline: none;
+    resize: none;
+    min-height: 44px;
+    line-height: 1.4;
   }
-  .crm-colrow .crit textarea:focus { border-color: var(--purple); }
+  .crm-colrow .crit textarea:focus {
+    border-color: var(--purple);
+  }
 
   /* ── Error banner ── */
   .crm-err-banner {
-    background: rgba(231,31,132,0.1); border: 1px solid rgba(231,31,132,0.3);
-    border-radius: 9px; padding: 10px 14px; font-size: 12.5px; color: var(--text); margin-bottom: 12px;
+    background: rgba(231, 31, 132, 0.1);
+    border: 1px solid rgba(231, 31, 132, 0.3);
+    border-radius: 9px;
+    padding: 10px 14px;
+    font-size: 12.5px;
+    color: var(--text);
+    margin-bottom: 12px;
   }
 
   /* ── Responsive ── */
   @media (max-width: 760px) {
-    .crm-kanban { flex-direction: column; }
-    .crm-col { width: 100%; min-width: unset; }
-    .crm-colrow .crit { grid-template-columns: 1fr; }
-    .crm-head { gap: 8px; }
+    .crm-kanban {
+      flex-direction: column;
+    }
+    .crm-col {
+      width: 100%;
+      min-width: unset;
+    }
+    .crm-colrow .crit {
+      grid-template-columns: 1fr;
+    }
+    .crm-head {
+      gap: 8px;
+    }
   }
 </style>

--- a/frontend/src/routes/(admin)/admin/crm/+page.svelte
+++ b/frontend/src/routes/(admin)/admin/crm/+page.svelte
@@ -243,7 +243,7 @@
 <!-- ── Column Editor Modal ── -->
 {#if editingCols}
   <div class="admin-overlay" role="presentation" onclick={() => editingCols = false}>
-    <div class="admin-modal wide" role="dialog" aria-modal="true" aria-label="Editar colunas do pipeline" onclick={(e) => e.stopPropagation()}>
+    <div class="admin-modal wide" role="dialog" aria-modal="true" aria-label="Editar colunas do pipeline" tabindex="-1" onclick={(e) => e.stopPropagation()} onkeydown={(e) => e.stopPropagation()}>
       <div class="admin-modal-head">
         <h3>Editar colunas do pipeline</h3>
         <span class="crumbs">/ crm / colunas</span>
@@ -253,13 +253,14 @@
         {#if colsError}
           <div class="crm-err-banner">{colsError}</div>
         {/if}
-        <div class="crm-coleditor" ondragover={(e) => e.preventDefault()}>
+        <div class="crm-coleditor" role="list" ondragover={(e) => e.preventDefault()}>
           {#each editCols as c (c.id)}
             <div class="crm-colrow {colDragId === c.id ? 'dragging' : ''} {colDropTarget?.id === c.id ? (colDropTarget?.after ? 'drop-after' : 'drop-before') : ''}"
+              role="listitem"
               ondragover={(e) => { e.preventDefault(); if (colDragId && colDragId !== c.id) { const r = e.currentTarget.getBoundingClientRect(); colDropTarget = { id: c.id, after: e.clientY > r.top + r.height / 2 }; } }}
               ondrop={(e) => { e.preventDefault(); editorDrop(c.id); }}>
               <div class="r1">
-                <span class="handle" draggable="true"
+                <span class="handle" draggable="true" role="button" tabindex="0" aria-label="Arraste para reordenar a coluna"
                   ondragstart={() => colDragId = c.id}
                   ondragend={() => { colDragId = null; colDropTarget = null; }}
                   title="arraste para reordenar">
@@ -269,7 +270,7 @@
                   oninput={() => { if (c.title.trim() && invalidColIds.has(c.id)) { invalidColIds = new Set([...invalidColIds].filter(id => id !== c.id)); } }}/>
                 <div class="crm-swatches">
                   {#each COL_COLORS as col}
-                    <button type="button" class="crm-swatch {c.color === col ? 'on' : ''}" style="background:{col}" onclick={() => editorUpd(c.id, { color: col })}></button>
+                    <button type="button" class="crm-swatch {c.color === col ? 'on' : ''}" style="background:{col}" aria-label={`Cor ${col}`} onclick={() => editorUpd(c.id, { color: col })}></button>
                   {/each}
                 </div>
                 {#if c.is_default}
@@ -282,12 +283,14 @@
               </div>
               <div class="crit">
                 <div class="f">
-                  <label>Critério de entrada</label>
-                  <textarea bind:value={c.entry_hint} placeholder="Quando um lead entra nesta coluna?"></textarea>
+                  <label>Critério de entrada
+                    <textarea bind:value={c.entry_hint} placeholder="Quando um lead entra nesta coluna?"></textarea>
+                  </label>
                 </div>
                 <div class="f">
-                  <label>Critério de saída</label>
-                  <textarea bind:value={c.exit_hint} placeholder="Quando um lead sai desta coluna?"></textarea>
+                  <label>Critério de saída
+                    <textarea bind:value={c.exit_hint} placeholder="Quando um lead sai desta coluna?"></textarea>
+                  </label>
                 </div>
               </div>
             </div>
@@ -313,7 +316,7 @@
 <!-- ── Quick column editor (gear button on the card) ── -->
 {#if quickCol}
   <div class="admin-overlay" role="presentation" onclick={closeQuickEditor}>
-    <div class="admin-modal" role="dialog" aria-modal="true" aria-label="Editar coluna" onclick={(e) => e.stopPropagation()}>
+    <div class="admin-modal" role="dialog" aria-modal="true" aria-label="Editar coluna" tabindex="-1" onclick={(e) => e.stopPropagation()} onkeydown={(e) => e.stopPropagation()}>
       <div class="admin-modal-head">
         <h3>Editar coluna</h3>
         <span class="crumbs">/ crm / colunas / {quickCol.title}</span>
@@ -328,7 +331,7 @@
             <input class="cname {!quickCol.title.trim() ? 'invalid' : ''}" bind:value={quickCol.title}/>
             <div class="crm-swatches">
               {#each COL_COLORS as col}
-                <button type="button" class="crm-swatch {quickCol.color === col ? 'on' : ''}" style="background:{col}" onclick={() => quickCol = quickCol && { ...quickCol, color: col }}></button>
+                <button type="button" class="crm-swatch {quickCol.color === col ? 'on' : ''}" style="background:{col}" aria-label={`Cor ${col}`} onclick={() => quickCol = quickCol && { ...quickCol, color: col }}></button>
               {/each}
             </div>
             {#if quickCol.is_default}
@@ -340,12 +343,14 @@
           </div>
           <div class="crit">
             <div class="f">
-              <label>Critério de entrada</label>
-              <textarea bind:value={quickCol.entry_hint} placeholder="Quando um lead entra nesta coluna?"></textarea>
+              <label>Critério de entrada
+                <textarea bind:value={quickCol.entry_hint} placeholder="Quando um lead entra nesta coluna?"></textarea>
+              </label>
             </div>
             <div class="f">
-              <label>Critério de saída</label>
-              <textarea bind:value={quickCol.exit_hint} placeholder="Quando um lead sai desta coluna?"></textarea>
+              <label>Critério de saída
+                <textarea bind:value={quickCol.exit_hint} placeholder="Quando um lead sai desta coluna?"></textarea>
+              </label>
             </div>
           </div>
         </div>

--- a/supabase/migrations/20260628000200_grant_products_dml.sql
+++ b/supabase/migrations/20260628000200_grant_products_dml.sql
@@ -1,0 +1,14 @@
+-- Migration: grant DML on public.products to API roles
+--
+-- A migration original de products (20260523000000) criou a tabela SEM grants
+-- explícitos de DML. Em projetos Supabase hospedados isso "funciona" por
+-- privilégios herdados configurados no provisionamento do projeto, mas em um
+-- stack limpo aplicado só pelas migrations (ex.: `supabase db reset` no CI) o
+-- backend recebe 42501 "permission denied for table products" ao inserir/
+-- atualizar/remover produtos. Alinha products ao padrão de notifications/crm_columns.
+--
+-- RLS continua valendo: anon/authenticated só enxergam produtos publicados pela
+-- policy de SELECT; service_role (usado pelo backend) tem acesso total.
+
+GRANT ALL ON public.products TO service_role;
+GRANT SELECT ON public.products TO anon, authenticated;


### PR DESCRIPTION
## Fix completo do CI da `main`

A `main` está com **CI vermelho** desde o merge do PR #224. A pipeline morria já no primeiro passo (ESLint do backend), mascarando uma cadeia de falhas pré-existentes em todos os jobs. Este PR conserta **todas** elas. Nenhuma mudança de comportamento de runtime além do grant de banco (que corrige um bug real).

### Damage report (antes → depois)
| Job · Step | Antes | Depois |
|---|---|---|
| Lint · ESLint backend | ❌ `res` não usado | ✅ |
| Lint · ESLint frontend | ❌ 13 erros a11y | ✅ |
| Lint · Prettier `--check .` | ❌ 82 arquivos | ✅ (ver .prettierignore) |
| Typecheck · backend | ❌ exactOptionalPropertyTypes | ✅ |
| Typecheck · frontend | ✅ | ✅ |
| Test · backend (crm_columns) | ❌ migration renomeada | ✅ |
| Test · backend (produtos, 5) | ❌ `42501 permission denied` | ✅ |
| Test · frontend | ✅ 97 | ✅ |
| Build · backend + frontend | ✅ | ✅ |

### O que foi corrigido
1. **lint backend** (`lib/supabase.ts`): remove `res` não usado.
2. **typecheck** (`crm-columns.routes.ts`): spread condicional ao chamar `createColumn`.
3. **teste crm_columns** (`tests/database/crm_columns.test.ts`): reescrito p/ o schema atual (migration `20260625000100/200`); apontava p/ arquivo renomeado.
4. **a11y frontend** (`crm/+page.svelte`): 13 erros do ESLint (dialog `tabindex`+`onkeydown`, `role` list/listitem nos containers de drag-and-drop, `role`/`aria` no handle, `aria-label` nos botões de cor, labels associados aos textareas).
5. **grant de produtos** (`migration 20260628000200_grant_products_dml.sql`): a migration original de products criou a tabela **sem grants de DML**; em stack limpo (CI faz `supabase db reset`) o backend recebia `42501 permission denied for table products` — bug real, não só de teste. Concede `ALL` a `service_role` e `SELECT` a anon/authenticated (RLS preservada).
6. **prettier** (`.prettierignore` + formatação): exclui o subprojeto Docusaurus (`gh-pages/`, ~77 docs) e artefatos gerados do `prettier --check .`; formata os 5 arquivos de código restantes.

### Evidências (local, replicando os passos do CI)
```
prettier --check .            → 0
backend  lint / typecheck     → 0 / 0
frontend lint / typecheck     → 0 / 0
backend  test                 → ok (crm_columns 4; produtos validados contra stack limpo via sb_secret)
frontend test                 → 97 passed
backend/frontend build        → ok
```
Diagnóstico de produtos confirmado: contra um `supabase db reset` limpo + chave `sb_secret` (idêntico ao CI), o INSERT ia de `42501` para `OK` após a migration de grant.

### Notas
- Mudanças de código restritas a lint/tipos/testes/format + 1 migration de grant; nenhum endpoint alterado.
- Após o merge, o PR #225 (#187, endpoint de notificações) deve ficar verde ao rebasear sobre a `main`.
