### PR TITLE
fix(docs): deep-link abre aba correta ao clicar em RF/RNF na rastreabilidade

### DIFF
--- a/gh-pages/docusaurus/docs/iteracoes/iteracao-1/features/f09.mdx
+++ b/gh-pages/docusaurus/docs/iteracoes/iteracao-1/features/f09.mdx
@@ -20,7 +20,7 @@ Esta funcionalidade exige **login de administrador**. Credenciais para o profess
 
 Selecione um requisito na navegação abaixo. Cada um traz seus critérios de aceite, regras de negócio e um espaço para o **screenshot da funcionalidade em funcionamento** (substitua a imagem de placeholder pela captura real).
 
-<Tabs>
+<Tabs queryString="tab">
 <TabItem value="rf08" label="RF08">
 
 #### RF08 — Autenticar perfil de usuário

--- a/gh-pages/docusaurus/docs/iteracoes/iteracao-1/features/f10.mdx
+++ b/gh-pages/docusaurus/docs/iteracoes/iteracao-1/features/f10.mdx
@@ -20,7 +20,7 @@ Esta funcionalidade exige **login de administrador**. Credenciais para o profess
 
 Selecione um requisito na navegação abaixo. Cada um traz seus critérios de aceite, regras de negócio e um espaço para o **screenshot da funcionalidade em funcionamento** (substitua a imagem de placeholder pela captura real).
 
-<Tabs>
+<Tabs queryString="tab">
 <TabItem value="rf10" label="RF10">
 
 #### RF10 — Acessar painel administrativo

--- a/gh-pages/docusaurus/docs/iteracoes/iteracao-1/features/f11.mdx
+++ b/gh-pages/docusaurus/docs/iteracoes/iteracao-1/features/f11.mdx
@@ -20,7 +20,7 @@ Esta funcionalidade exige **login de administrador**. Credenciais para o profess
 
 Selecione um requisito na navegação abaixo. Cada um traz seus critérios de aceite, regras de negócio e um espaço para o **screenshot da funcionalidade em funcionamento** (substitua a imagem de placeholder pela captura real).
 
-<Tabs>
+<Tabs queryString="tab">
 <TabItem value="rf11" label="RF11">
 
 #### RF11 — Editar informações dos membros

--- a/gh-pages/docusaurus/docs/iteracoes/iteracao-1/features/f12.mdx
+++ b/gh-pages/docusaurus/docs/iteracoes/iteracao-1/features/f12.mdx
@@ -20,7 +20,7 @@ Esta funcionalidade exige **login de administrador**. Credenciais para o profess
 
 Selecione um requisito na navegação abaixo. Cada um traz seus critérios de aceite, regras de negócio e um espaço para o **screenshot da funcionalidade em funcionamento** (substitua a imagem de placeholder pela captura real).
 
-<Tabs>
+<Tabs queryString="tab">
 <TabItem value="rf21" label="RF21">
 
 #### RF21 — Cadastrar produto SaaS

--- a/gh-pages/docusaurus/docs/iteracoes/iteracao-1/features/f13.mdx
+++ b/gh-pages/docusaurus/docs/iteracoes/iteracao-1/features/f13.mdx
@@ -20,7 +20,7 @@ Esta funcionalidade exige **login de administrador**. Credenciais para o profess
 
 Selecione um requisito na navegação abaixo. Cada um traz seus critérios de aceite, regras de negócio e um espaço para o **screenshot da funcionalidade em funcionamento** (substitua a imagem de placeholder pela captura real).
 
-<Tabs>
+<Tabs queryString="tab">
 <TabItem value="rf25" label="RF25">
 
 #### RF25 — Publicar produto SaaS

--- a/gh-pages/docusaurus/docs/iteracoes/iteracao-1/features/f14.mdx
+++ b/gh-pages/docusaurus/docs/iteracoes/iteracao-1/features/f14.mdx
@@ -16,7 +16,7 @@ import TabItem from '@theme/TabItem';
 
 Selecione um requisito na navegação abaixo. Cada um traz seus critérios de aceite, regras de negócio e um espaço para o **screenshot da funcionalidade em funcionamento** (substitua a imagem de placeholder pela captura real).
 
-<Tabs>
+<Tabs queryString="tab">
 <TabItem value="rf27" label="RF27">
 
 #### RF27 — Cadastrar contato com a empresa

--- a/gh-pages/docusaurus/docs/iteracoes/iteracao-1/features/f15.mdx
+++ b/gh-pages/docusaurus/docs/iteracoes/iteracao-1/features/f15.mdx
@@ -16,7 +16,7 @@ import TabItem from '@theme/TabItem';
 
 Selecione um requisito na navegação abaixo. Cada um traz seus critérios de aceite, regras de negócio e um espaço para o **screenshot da funcionalidade em funcionamento** (substitua a imagem de placeholder pela captura real).
 
-<Tabs>
+<Tabs queryString="tab">
 <TabItem value="rf50" label="RF50">
 
 #### RF50 — Consultar detalhes de produto na vitrine

--- a/gh-pages/docusaurus/docs/iteracoes/iteracao-1/features/f16.mdx
+++ b/gh-pages/docusaurus/docs/iteracoes/iteracao-1/features/f16.mdx
@@ -20,7 +20,7 @@ Esta funcionalidade exige **login de administrador**. Credenciais para o profess
 
 Selecione um requisito na navegação abaixo. Cada um traz seus critérios de aceite, regras de negócio e um espaço para o **screenshot da funcionalidade em funcionamento** (substitua a imagem de placeholder pela captura real).
 
-<Tabs>
+<Tabs queryString="tab">
 <TabItem value="rf28" label="RF28">
 
 #### RF28 — Cadastrar artigo de FAQ

--- a/gh-pages/docusaurus/docs/iteracoes/iteracao-1/features/f17.mdx
+++ b/gh-pages/docusaurus/docs/iteracoes/iteracao-1/features/f17.mdx
@@ -20,7 +20,7 @@ Esta funcionalidade exige **login de administrador**. Credenciais para o profess
 
 Selecione um requisito na navegação abaixo. Cada um traz seus critérios de aceite, regras de negócio e um espaço para o **screenshot da funcionalidade em funcionamento** (substitua a imagem de placeholder pela captura real).
 
-<Tabs>
+<Tabs queryString="tab">
 <TabItem value="rf32" label="RF32">
 
 #### RF32 — Publicar artigo de FAQ

--- a/gh-pages/docusaurus/docs/iteracoes/iteracao-1/features/f18.mdx
+++ b/gh-pages/docusaurus/docs/iteracoes/iteracao-1/features/f18.mdx
@@ -16,7 +16,7 @@ import TabItem from '@theme/TabItem';
 
 Selecione um requisito na navegação abaixo. Cada um traz seus critérios de aceite, regras de negócio e um espaço para o **screenshot da funcionalidade em funcionamento** (substitua a imagem de placeholder pela captura real).
 
-<Tabs>
+<Tabs queryString="tab">
 <TabItem value="rf34" label="RF34">
 
 #### RF34 — Avaliar artigo de FAQ

--- a/gh-pages/docusaurus/src/components/TraceabilityFlow/index.tsx
+++ b/gh-pages/docusaurus/src/components/TraceabilityFlow/index.tsx
@@ -53,7 +53,7 @@ function featureHref(featId: string): string {
 function rfHref(rfId: string): string {
   const feat = RF_TO_FEATURE[rfId];
   if (feat && IT1_FEATURE_PATHS[feat]) {
-    return IT1_FEATURE_PATHS[feat];
+    return `${IT1_FEATURE_PATHS[feat]}?tab=${rfId.toLowerCase()}`;
   }
   return '/backlog/requisitos';
 }
@@ -118,27 +118,29 @@ export const TREE: OEDef[] = [
 ];
 
 /* ── RNFs — seção independente ─────────────────────────────────── */
+/* href = feature page com ?tab=rnfNN quando existe aba dedicada,
+   ou /backlog/requisitos#rnfs para RNFs gerais sem página de feature. */
 const RNFS: RnfDef[] = [
-  {id: 'RNF01', label: 'RNF01 · Isolamento admin',    href: '/iteracoes/iteracao-1/features/f09'},
-  {id: 'RNF02', label: 'RNF02 · Tempo vitrine',       href: '/iteracoes/iteracao-1/features/f14'},
-  {id: 'RNF03', label: 'RNF03 · Tempo adm.',          href: '/iteracoes/iteracao-1/features/f09'},
-  {id: 'RNF04', label: 'RNF04 · SSR vitrine',         href: '/iteracoes/iteracao-1/features/f12'},
-  {id: 'RNF05', label: 'RNF05 · SEO',                 href: '/iteracoes/iteracao-1/features/f12'},
+  {id: 'RNF01', label: 'RNF01 · Isolamento admin',    href: '/iteracoes/iteracao-1/features/f09?tab=rnf01'},
+  {id: 'RNF02', label: 'RNF02 · Tempo vitrine',       href: '/iteracoes/iteracao-1/features/f14?tab=rnf02'},
+  {id: 'RNF03', label: 'RNF03 · Tempo adm.',          href: '/iteracoes/iteracao-1/features/f09?tab=rnf03'},
+  {id: 'RNF04', label: 'RNF04 · SSR vitrine',         href: '/iteracoes/iteracao-1/features/f12?tab=rnf04'},
+  {id: 'RNF05', label: 'RNF05 · SEO',                 href: '/iteracoes/iteracao-1/features/f12?tab=rnf05'},
   {id: 'RNF07', label: 'RNF07 · OWASP Top 10',        href: '/backlog/requisitos#rnfs'},
-  {id: 'RNF08', label: 'RNF08 · Criptografia',        href: '/iteracoes/iteracao-1/features/f09'},
-  {id: 'RNF09', label: 'RNF09 · RLS por linha',       href: '/backlog/requisitos#rnfs'},
-  {id: 'RNF10', label: 'RNF10 · Rate limit form.',    href: '/iteracoes/iteracao-1/features/f14'},
-  {id: 'RNF11', label: 'RNF11 · Conformidade LGPD',   href: '/backlog/requisitos#rnfs'},
+  {id: 'RNF08', label: 'RNF08 · Criptografia',        href: '/iteracoes/iteracao-1/features/f09?tab=rnf08'},
+  {id: 'RNF09', label: 'RNF09 · RLS por linha',       href: '/iteracoes/iteracao-1/features/f10?tab=rnf09'},
+  {id: 'RNF10', label: 'RNF10 · Rate limit form.',    href: '/iteracoes/iteracao-1/features/f14?tab=rnf10'},
+  {id: 'RNF11', label: 'RNF11 · Conformidade LGPD',   href: '/iteracoes/iteracao-1/features/f14?tab=rnf11'},
   {id: 'RNF12', label: 'RNF12 · Responsividade',      href: '/backlog/requisitos#rnfs'},
-  {id: 'RNF13', label: 'RNF13 · Bilinguismo',         href: '/iteracoes/iteracao-1/features/f12'},
+  {id: 'RNF13', label: 'RNF13 · Bilinguismo',         href: '/iteracoes/iteracao-1/features/f12?tab=rnf13'},
   {id: 'RNF14', label: 'RNF14 · Escalabilidade',      href: '/backlog/requisitos#rnfs'},
-  {id: 'RNF15', label: 'RNF15 · Carga concorrente',   href: '/iteracoes/iteracao-1/features/f12'},
+  {id: 'RNF15', label: 'RNF15 · Carga concorrente',   href: '/backlog/requisitos#rnfs'},
   {id: 'RNF16', label: 'RNF16 · Stack obrigatório',   href: '/backlog/requisitos#rnfs'},
   {id: 'RNF17', label: 'RNF17 · Cobertura testes',    href: '/backlog/requisitos#rnfs'},
   {id: 'RNF18', label: 'RNF18 · Portabilidade',       href: '/backlog/requisitos#rnfs'},
-  {id: 'RNF19', label: 'RNF19 · Navegação intuitiva', href: '/iteracoes/iteracao-1/features/f12'},
-  {id: 'RNF20', label: 'RNF20 · Disponibilidade',     href: '/iteracoes/iteracao-1/features/f15'},
-  {id: 'RNF21', label: 'RNF21 · Drag-drop cards',     href: '/iteracoes/iteracao-1/features/f15'},
+  {id: 'RNF19', label: 'RNF19 · Navegação intuitiva', href: '/iteracoes/iteracao-1/features/f12?tab=rnf19'},
+  {id: 'RNF20', label: 'RNF20 · Disponibilidade',     href: '/iteracoes/iteracao-1/features/f15?tab=rnf20'},
+  {id: 'RNF21', label: 'RNF21 · Drag-drop cards',     href: '/backlog/requisitos#rnfs'},
   {id: 'RNF22', label: 'RNF22 · Drag-drop colunas',   href: '/backlog/requisitos#rnfs'},
   {id: 'RNF23', label: 'RNF23 · Resumo tickets',      href: '/backlog/requisitos#rnfs'},
   {id: 'RNF24', label: 'RNF24 · Cards CRM',           href: '/backlog/requisitos#rnfs'},


### PR DESCRIPTION
## Problema
Clicar num nó de RF ou RNF na árvore de rastreabilidade abria a página da feature, mas **sem selecionar a aba correta** no mini-sidebar — o usuário chegava sempre na primeira aba (RF08 p/ F09, etc.) e precisava navegar manualmente até o requisito.

## Solução
`<Tabs queryString="tab">` é uma prop nativa do Docusaurus que faz o componente ler `?tab=valor` da URL e abrir a aba correspondente automaticamente na chegada.

### Mudanças
- **10 feature pages (F09–F18)**: `<Tabs>` → `<Tabs queryString="tab">`; nenhuma outra alteração.
- **TraceabilityFlow / `rfHref()`**: link de cada RF passa a incluir `?tab=rfNN` (ex: RF08 → `/iteracoes/.../f09?tab=rf08`).
- **TraceabilityFlow / array `RNFS`**: cada RNF com aba dedicada numa feature page recebe `?tab=rnfNN`; RNFs gerais (sem aba na IT1) continuam apontando para `/backlog/requisitos#rnfs`.

## Test plan
- [x] `docusaurus build` sem erros
- [x] Clicar em RF08 no grafo → abre F09 com aba RF08 selecionada
- [x] Clicar em RNF08 no grafo → abre F09 com aba RNF08 selecionada
- [x] Clicar em RF21 → abre F12 com aba RF21 selecionada
- [x] RNF07 (geral) → abre tabela de requisitos na seção RNFs (sem ?tab)