### PR TITLE
feat(notifications): marcar como lida com atualização otimista (#190)

### DIFF
--- a/frontend/src/lib/utils/notifications.test.ts
+++ b/frontend/src/lib/utils/notifications.test.ts
@@ -4,6 +4,7 @@ import {
   formatDayLabel,
   relativeTime,
   iconForTipo,
+  setStatus,
   type Notification,
 } from './notifications';
 
@@ -69,5 +70,26 @@ describe('iconForTipo', () => {
   it('mapeia novo_lead e tem fallback', () => {
     expect(iconForTipo('novo_lead')).toEqual({ icon: 'users', color: '#7f3fe5' });
     expect(iconForTipo('qualquer_outro').icon).toBe('bell');
+  });
+});
+
+describe('setStatus', () => {
+  const base: Notification[] = [
+    mk('a', '2026-06-30T10:00:00.000Z', 'unread'),
+    mk('b', '2026-06-30T09:00:00.000Z', 'unread'),
+  ];
+
+  it('altera apenas o item alvo, sem mutar o array original', () => {
+    const next = setStatus(base, 'a', 'read');
+    expect(next.find((n) => n.id === 'a')!.status).toBe('read');
+    expect(next.find((n) => n.id === 'b')!.status).toBe('unread');
+    // imutabilidade
+    expect(base.find((n) => n.id === 'a')!.status).toBe('unread');
+    expect(next).not.toBe(base);
+  });
+
+  it('id inexistente mantém os status', () => {
+    const next = setStatus(base, 'zzz', 'read');
+    expect(next.map((n) => n.status)).toEqual(['unread', 'unread']);
   });
 });

--- a/frontend/src/lib/utils/notifications.ts
+++ b/frontend/src/lib/utils/notifications.ts
@@ -91,3 +91,13 @@ export function iconForTipo(tipo: string): NotifVisual {
       return { icon: 'bell', color: '#7f3fe5' };
   }
 }
+
+// Retorna uma nova lista com o status de um item alterado (imutável). Usado no
+// update otimista e no rollback ao marcar uma notificação como lida (#190).
+export function setStatus(
+  items: Notification[],
+  id: string,
+  status: NotificationStatus
+): Notification[] {
+  return items.map((n) => (n.id === id ? { ...n, status } : n));
+}

--- a/frontend/src/routes/(admin)/admin/notificacoes/+page.svelte
+++ b/frontend/src/routes/(admin)/admin/notificacoes/+page.svelte
@@ -1,10 +1,12 @@
 <script lang="ts">
-  import { Bell, Users, Check, ShieldAlert } from 'lucide-svelte';
+  import { Bell, Users, Check, ShieldAlert, X } from 'lucide-svelte';
+  import { apiFetch } from '$lib/api/backend';
   import { unreadCount } from '$lib/stores/notifications';
   import {
     groupByDay,
     relativeTime,
     iconForTipo,
+    setStatus,
     type Notification,
   } from '$lib/utils/notifications';
 
@@ -18,13 +20,21 @@
   }>();
 
   let tab = $state<'all' | 'unread'>('all');
+  // Cópia local mutável para permitir o update otimista ao marcar como lida.
+  let items = $state<Notification[]>([]);
+  let pending = $state<Set<string>>(new Set());
+  let actionError = $state('');
+
+  $effect(() => {
+    items = data.notifications.map((n) => ({ ...n }));
+  });
 
   const unreadOnly = (list: Notification[]) => list.filter((n) => n.status === 'unread');
-  let filtered = $derived(tab === 'unread' ? unreadOnly(data.notifications) : data.notifications);
+  let filtered = $derived(tab === 'unread' ? unreadOnly(items) : items);
   let groups = $derived(groupByDay(filtered));
-  let unreadTotal = $derived(unreadOnly(data.notifications).length);
+  let unreadTotal = $derived(unreadOnly(items).length);
 
-  // Mantém o badge global do shell em sincronia com o que a central conhece.
+  // Mantém o badge global do shell em sincronia com o load do servidor.
   $effect(() => {
     unreadCount.set(data.unreadCount);
   });
@@ -34,6 +44,32 @@
   function humanize(tipo: string): string {
     const s = tipo.replace(/_/g, ' ').trim();
     return s.charAt(0).toUpperCase() + s.slice(1);
+  }
+
+  // Marca uma notificação como lida com atualização otimista do contador
+  // (badge global + UI da central) e rollback em caso de erro do backend. (#190)
+  async function markAsRead(n: Notification) {
+    if (n.status === 'read' || pending.has(n.id)) return;
+
+    pending = new Set(pending).add(n.id);
+    items = setStatus(items, n.id, 'read'); // otimista
+    unreadCount.update((c) => Math.max(0, c - 1));
+
+    try {
+      await apiFetch(`/admin/notifications/${n.id}`, {
+        method: 'PATCH',
+        body: JSON.stringify({ status: 'read' }),
+      });
+      actionError = '';
+    } catch {
+      items = setStatus(items, n.id, 'unread'); // rollback
+      unreadCount.update((c) => c + 1);
+      actionError = 'Não foi possível marcar como lida. Tente novamente.';
+    } finally {
+      const next = new Set(pending);
+      next.delete(n.id);
+      pending = next;
+    }
   }
 </script>
 
@@ -54,9 +90,18 @@
       {/if}
     </header>
 
+    {#if actionError}
+      <div class="notif-err-banner action">
+        <span>{actionError}</span>
+        <button class="dismiss" aria-label="Fechar aviso" onclick={() => (actionError = '')}>
+          <X size={14} />
+        </button>
+      </div>
+    {/if}
+
     <div class="notif-tabs">
       <button class="tab {tab === 'all' ? 'on' : ''}" onclick={() => (tab = 'all')}>
-        Tudo <span class="badge">{data.notifications.length}</span>
+        Tudo <span class="badge">{items.length}</span>
       </button>
       <button class="tab {tab === 'unread' ? 'on' : ''}" onclick={() => (tab = 'unread')}>
         Não lidas <span class="badge">{unreadTotal}</span>
@@ -86,6 +131,17 @@
                   <div class="desc">{n.conteudo}</div>
                 </div>
                 <span class="t">{relativeTime(n.created_at)}</span>
+                {#if n.status === 'unread'}
+                  <button
+                    class="mark-btn"
+                    title="Marcar como lida"
+                    aria-label="Marcar como lida"
+                    disabled={pending.has(n.id)}
+                    onclick={() => markAsRead(n)}
+                  >
+                    <Check size={14} />
+                  </button>
+                {/if}
               </li>
             {/each}
           </ul>
@@ -270,5 +326,53 @@
     background: var(--hot-soft, rgba(231, 31, 132, 0.08));
     color: var(--text);
     font-size: 13px;
+  }
+  .notif-err-banner.action {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+    margin-bottom: 10px;
+  }
+  .notif-err-banner.action span {
+    flex: 1;
+  }
+  .notif-err-banner .dismiss {
+    background: transparent;
+    border: 0;
+    color: var(--text-muted);
+    cursor: pointer;
+    display: grid;
+    place-items: center;
+    padding: 2px;
+    border-radius: 6px;
+  }
+  .notif-err-banner .dismiss:hover {
+    color: var(--text);
+  }
+
+  .mark-btn {
+    flex-shrink: 0;
+    width: 26px;
+    height: 26px;
+    border-radius: 7px;
+    border: 1px solid var(--line);
+    background: transparent;
+    color: var(--text-muted);
+    cursor: pointer;
+    display: grid;
+    place-items: center;
+    transition:
+      background 0.12s,
+      color 0.12s,
+      border-color 0.12s;
+  }
+  .mark-btn:hover:not(:disabled) {
+    background: var(--pos-soft, rgba(102, 223, 122, 0.18));
+    color: var(--green);
+    border-color: transparent;
+  }
+  .mark-btn:disabled {
+    opacity: 0.5;
+    cursor: default;
   }
 </style>


### PR DESCRIPTION
## Feature entregue

> Formato FDD: **[ação] [resultado] [objeto]**

Marcar notificação como lida com atualização otimista do contador

| Campo | Valor |
|---|---|
| **CP** | CP9 — Sistema de Notificações no Sistema |
| **Iteração** | IT2 — Lead Capture |
| **Issue** | Closes #190 (sub-issue 5/5 da feature #179) · bloqueada por #188, #189 |
| **Chief Programmer** | @HeitorM50 |

---

## O que foi implementado

- Botão **"marcar como lida"** (ícone Check) nas linhas **não lidas** da central `/admin/notificacoes`.
- **Atualização otimista**: ao clicar, o status muda **na hora** e o contador decrementa imediatamente — tanto na UI da central (pill + aba "Não lidas") quanto no **badge global do shell** (sino da topbar + contador da sidebar), via store `unreadCount`, **sem reload**.
- **Rollback** em caso de erro do backend: status e contador voltam ao estado anterior + **banner de erro** dismissível.
- Guarda contra **clique duplo** (`pending` por id) e botão desabilitado durante a requisição.
- Reusa o **PATCH `/api/admin/notifications/:id`** do #188 (via `apiFetch`, auth por cookie).
- Helper puro `setStatus(items, id, status)` (usado no otimista e no rollback) com **testes Vitest**.

---

## DoD — Definition of Done

- [x] Critério de aceite validado (muda status + decrementa otimista; rollback em erro)
- [x] Testes automatizados passando — frontend (inclui 2 novos de `setStatus`)
- [x] Lint/typecheck/build/prettier do frontend sem erros
- [ ] CI verde — **stacked** sobre #189 (#235); verde ao rebasear após #189 mergear
- [ ] Validação parcial do cliente registrada na issue
- [x] Padrão otimista consistente com o toggle de publicação do FAQ; admin PT-only
- [x] a11y: botão com `aria-label`; sem secrets

---

## Checklist de revisão (para o revisor)

- [x] Lógica correta segundo o critério de aceitação (otimista + rollback)
- [x] Sem código morto ou TODO não rastreado
- [x] Nenhuma credencial/dado sensível exposto
- [x] Nomes seguem a convenção do projeto

---

## Evidências (local, passos do CI)

```
frontend: svelte-kit sync
npm run lint       → 0
npm run typecheck  → 0
npm test           → ok (setStatus: altera só o alvo, imutável, id inexistente)
npm run build      → 0
prettier --check . → 0
```

Smoke manual: em `/admin/notificacoes`, clicar "marcar como lida" → a linha perde o realce e o contador (pill/abas/sino/sidebar) decrementa na hora; com o backend fora do ar, o clique reverte (status + contador) e mostra o banner de erro.

---

## Notas para o revisor

- **PR empilhada (stacked) sobre a branch do #189 (PR #235)** — o diff mostra apenas a interação de marcar como lida. Re-apontar a base para `main` após #189 mergear.
- Somente **uma direção** (marcar como lida), coerente com o AC.
- Fecha a **F07** (#179): schema #186 → GET #187 → PATCH #188 → central #189 → **otimista #190**.
