### PR TITLE
feat(notifications): gerenciar templates de notificações (F08)

### DIFF
--- a/backend/src/notification-templates/notification-templates.routes.ts
+++ b/backend/src/notification-templates/notification-templates.routes.ts
@@ -1,0 +1,112 @@
+import { Router } from 'express';
+import { validateJWT } from '../middleware/validate-jwt.js';
+import { requireRole } from '../middleware/require-role.js';
+import {
+  listActiveTemplates,
+  createTemplate,
+  updateTemplate,
+  inactivateTemplate,
+  validateTemplateInput,
+  NotificationTemplateServiceError,
+} from './notification-templates.service.js';
+
+const notificationTemplatesRouter = Router();
+const ownerGuard = [validateJWT, requireRole('owner')];
+
+// GET /api/admin/notification-templates — lista templates ativos (F08 · #204).
+notificationTemplatesRouter.get('/', ...ownerGuard, async (_req, res) => {
+  try {
+    const templates = await listActiveTemplates();
+    res.status(200).json({ templates });
+  } catch (err) {
+    console.error('[notification-templates] list error:', err);
+    res.status(500).json({ message: 'Falha ao listar templates de notificação.' });
+  }
+});
+
+// POST /api/admin/notification-templates — cria template (RF15 · #202).
+notificationTemplatesRouter.post('/', ...ownerGuard, async (req, res) => {
+  const { tipo_evento, nome, conteudo } = req.body ?? {};
+
+  const validationError = validateTemplateInput({ tipo_evento, nome, conteudo });
+  if (validationError || !tipo_evento || !nome || !conteudo) {
+    res.status(400).json({ message: validationError ?? 'Campos obrigatórios ausentes.' });
+    return;
+  }
+
+  try {
+    const template = await createTemplate({ tipo_evento, nome, conteudo });
+    res.status(201).json(template);
+  } catch (err) {
+    if (err instanceof NotificationTemplateServiceError && err.code === 'DUPLICATE_EVENT') {
+      res.status(409).json({ message: err.message });
+      return;
+    }
+    console.error('[notification-templates] create error:', err);
+    res.status(500).json({ message: 'Falha ao criar template de notificação.' });
+  }
+});
+
+// PATCH /api/admin/notification-templates/:id — edita template (RF56 · #202).
+notificationTemplatesRouter.patch('/:id', ...ownerGuard, async (req, res) => {
+  const id = typeof req.params['id'] === 'string' ? req.params['id'].trim() : '';
+  const { tipo_evento, nome, conteudo } = req.body ?? {};
+
+  if (!id) {
+    res.status(400).json({ message: 'ID do template é obrigatório.' });
+    return;
+  }
+
+  const validationError = validateTemplateInput({ tipo_evento, nome, conteudo });
+  if (validationError) {
+    res.status(400).json({ message: validationError });
+    return;
+  }
+
+  try {
+    const template = await updateTemplate(id, { tipo_evento, nome, conteudo });
+    res.status(200).json(template);
+  } catch (err) {
+    if (err instanceof NotificationTemplateServiceError) {
+      if (err.code === 'NOT_FOUND') {
+        res.status(404).json({ message: err.message });
+        return;
+      }
+      if (err.code === 'DUPLICATE_EVENT') {
+        res.status(409).json({ message: err.message });
+        return;
+      }
+    }
+    console.error('[notification-templates] update error:', err);
+    res.status(500).json({ message: 'Falha ao atualizar template de notificação.' });
+  }
+});
+
+// DELETE /api/admin/notification-templates/:id — inativação lógica (RF57 · #203).
+// Idempotente: id inexistente ou já inativo retorna 404.
+notificationTemplatesRouter.delete('/:id', ...ownerGuard, async (req, res) => {
+  const id = typeof req.params['id'] === 'string' ? req.params['id'].trim() : '';
+
+  if (!id) {
+    res.status(400).json({ message: 'ID do template é obrigatório.' });
+    return;
+  }
+
+  try {
+    const updated = await inactivateTemplate(id);
+    if (!updated) {
+      res.status(404).json({ message: 'Template não encontrado.' });
+      return;
+    }
+    res.status(200).json(updated);
+  } catch (err) {
+    if (err instanceof NotificationTemplateServiceError && err.code === 'PROTECTED') {
+      res.status(409).json({ message: err.message });
+      return;
+    }
+    console.error('[notification-templates] delete error:', err);
+    res.status(500).json({ message: 'Falha ao remover template de notificação.' });
+  }
+});
+
+export { notificationTemplatesRouter };

--- a/backend/src/notification-templates/notification-templates.service.ts
+++ b/backend/src/notification-templates/notification-templates.service.ts
@@ -1,0 +1,192 @@
+import { getSupabaseClient } from '../config/supabase.js';
+
+export type NotificationTemplateRecord = {
+  id: string;
+  tipo_evento: string;
+  nome: string;
+  conteudo: string;
+  is_default: boolean;
+  active: boolean;
+  created_at: string;
+  updated_at: string;
+};
+
+export type NotificationTemplateInput = {
+  tipo_evento: string;
+  nome: string;
+  conteudo: string;
+};
+
+export type NotificationTemplateUpdateInput = Partial<NotificationTemplateInput>;
+
+// Tipo de evento reservado para o template padrão de fallback (seed #205) —
+// nunca pode ser usado por um template comum, para não colidir com o fallback.
+export const DEFAULT_TEMPLATE_TIPO_EVENTO = '__default__';
+
+const SELECT = 'id, tipo_evento, nome, conteudo, is_default, active, created_at, updated_at';
+
+export class NotificationTemplateServiceError extends Error {
+  constructor(
+    message: string,
+    public readonly code: 'NOT_FOUND' | 'DUPLICATE_EVENT' | 'PROTECTED' | 'INVALID'
+  ) {
+    super(message);
+    this.name = 'NotificationTemplateServiceError';
+  }
+}
+
+function isNonEmptyString(value: unknown): value is string {
+  return typeof value === 'string' && value.trim().length > 0;
+}
+
+function handleSupabaseError(err: unknown): never {
+  const e = err as { code?: string };
+  if (e.code === '23505') {
+    throw new NotificationTemplateServiceError(
+      'Já existe um template ativo para este tipo de evento.',
+      'DUPLICATE_EVENT'
+    );
+  }
+  throw err;
+}
+
+export function validateTemplateInput(input: {
+  tipo_evento?: unknown;
+  nome?: unknown;
+  conteudo?: unknown;
+}): string | null {
+  if (input.tipo_evento !== undefined && !isNonEmptyString(input.tipo_evento)) {
+    return "Campo 'tipo_evento' é obrigatório.";
+  }
+  if (input.nome !== undefined && !isNonEmptyString(input.nome)) {
+    return "Campo 'nome' é obrigatório.";
+  }
+  if (input.conteudo !== undefined && !isNonEmptyString(input.conteudo)) {
+    return "Campo 'conteudo' é obrigatório.";
+  }
+  if (input.tipo_evento === DEFAULT_TEMPLATE_TIPO_EVENTO) {
+    return 'Tipo de evento reservado para o template padrão do sistema.';
+  }
+  return null;
+}
+
+// Lista templates ativos, agrupáveis por tipo de evento no cliente (F08 · #204).
+export async function listActiveTemplates(): Promise<NotificationTemplateRecord[]> {
+  const supabase = getSupabaseClient();
+  const { data, error } = await supabase
+    .from('notification_templates')
+    .select(SELECT)
+    .eq('active', true)
+    .order('tipo_evento', { ascending: true });
+
+  if (error) throw error;
+  return (data ?? []) as NotificationTemplateRecord[];
+}
+
+// Cria um template associado a um tipo de evento (RF15). Duplicidade (mais de um
+// template ativo por tipo_evento) é impedida pelo índice único parcial da migration.
+export async function createTemplate(
+  input: NotificationTemplateInput
+): Promise<NotificationTemplateRecord> {
+  const supabase = getSupabaseClient();
+  const { data, error } = await supabase
+    .from('notification_templates')
+    .insert([
+      {
+        tipo_evento: input.tipo_evento.trim(),
+        nome: input.nome.trim(),
+        conteudo: input.conteudo,
+      },
+    ])
+    .select(SELECT)
+    .single();
+
+  if (error) handleSupabaseError(error);
+  return data as NotificationTemplateRecord;
+}
+
+// Edita um template existente sem duplicar o registro (RF56).
+export async function updateTemplate(
+  id: string,
+  input: NotificationTemplateUpdateInput
+): Promise<NotificationTemplateRecord> {
+  const supabase = getSupabaseClient();
+
+  const payload: Record<string, unknown> = {};
+  if (input.tipo_evento !== undefined) payload['tipo_evento'] = input.tipo_evento.trim();
+  if (input.nome !== undefined) payload['nome'] = input.nome.trim();
+  if (input.conteudo !== undefined) payload['conteudo'] = input.conteudo;
+
+  const { data, error } = await supabase
+    .from('notification_templates')
+    .update(payload)
+    .eq('id', id)
+    .select(SELECT)
+    .maybeSingle();
+
+  if (error) handleSupabaseError(error);
+  if (!data) throw new NotificationTemplateServiceError('Template não encontrado.', 'NOT_FOUND');
+  return data as NotificationTemplateRecord;
+}
+
+// Remove logicamente um template (active=false), nunca DELETE físico, para não
+// quebrar o histórico de notificações já enviadas com este template (RF57).
+// Idempotente: reaplicar em um template já inativo (ou inexistente) retorna null (404).
+// O template padrão de fallback nunca pode ser inativado (PROTECTED).
+export async function inactivateTemplate(id: string): Promise<NotificationTemplateRecord | null> {
+  const supabase = getSupabaseClient();
+
+  const { data: existing, error: fetchError } = await supabase
+    .from('notification_templates')
+    .select('is_default')
+    .eq('id', id)
+    .eq('active', true)
+    .maybeSingle();
+
+  if (fetchError) throw fetchError;
+  if (!existing) return null;
+  if (existing.is_default) {
+    throw new NotificationTemplateServiceError(
+      'O template padrão de fallback não pode ser removido.',
+      'PROTECTED'
+    );
+  }
+
+  const { data, error } = await supabase
+    .from('notification_templates')
+    .update({ active: false })
+    .eq('id', id)
+    .select(SELECT)
+    .maybeSingle();
+
+  if (error) throw error;
+  return (data as NotificationTemplateRecord) ?? null;
+}
+
+// Resolve o template ativo para um tipo de evento; cai para o template padrão de
+// fallback (seed #205) quando não há template específico configurado (RF57 · #203).
+export async function getTemplateForEvent(
+  tipoEvento: string
+): Promise<NotificationTemplateRecord | null> {
+  const supabase = getSupabaseClient();
+
+  const { data: specific, error: specificError } = await supabase
+    .from('notification_templates')
+    .select(SELECT)
+    .eq('tipo_evento', tipoEvento)
+    .eq('active', true)
+    .maybeSingle();
+
+  if (specificError) throw specificError;
+  if (specific) return specific as NotificationTemplateRecord;
+
+  const { data: fallback, error: fallbackError } = await supabase
+    .from('notification_templates')
+    .select(SELECT)
+    .eq('is_default', true)
+    .eq('active', true)
+    .maybeSingle();
+
+  if (fallbackError) throw fallbackError;
+  return (fallback as NotificationTemplateRecord) ?? null;
+}

--- a/backend/src/notification-templates/notification-templates.test.ts
+++ b/backend/src/notification-templates/notification-templates.test.ts
@@ -1,0 +1,195 @@
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import request from 'supertest';
+import express from 'express';
+import { notificationTemplatesRouter } from './notification-templates.routes.js';
+import { getSupabaseClient } from '../config/supabase.js';
+import { getTemplateForEvent } from './notification-templates.service.js';
+
+const originalBypass = process.env['ADMIN_AUTH_BYPASS'];
+
+// tipo_evento exclusivo desta suíte — permite limpar resíduos sem afetar dados reais.
+const TEST_TIPO = `template-ci-${Date.now()}`;
+
+beforeAll(async () => {
+  process.env['ADMIN_AUTH_BYPASS'] = 'true';
+  const supabase = getSupabaseClient();
+  await supabase.from('notification_templates').delete().like('tipo_evento', `${TEST_TIPO}%`);
+});
+
+afterAll(async () => {
+  const supabase = getSupabaseClient();
+  await supabase.from('notification_templates').delete().like('tipo_evento', `${TEST_TIPO}%`);
+
+  if (originalBypass === undefined) {
+    delete process.env['ADMIN_AUTH_BYPASS'];
+  } else {
+    process.env['ADMIN_AUTH_BYPASS'] = originalBypass;
+  }
+});
+
+const app = express();
+app.use(express.json());
+app.use('/admin/notification-templates', notificationTemplatesRouter);
+
+describe('Suite de testes de integração — POST /api/admin/notification-templates (RF15 · #202)', () => {
+  it('Com dados válidos, cria e persiste o template associado ao tipo de evento', async () => {
+    const res = await request(app)
+      .post('/admin/notification-templates')
+      .send({ tipo_evento: `${TEST_TIPO}-create`, nome: 'Novo lead', conteudo: 'Chegou um lead.' })
+      .expect(201);
+
+    expect(res.body.tipo_evento).toBe(`${TEST_TIPO}-create`);
+    expect(res.body.active).toBe(true);
+  });
+
+  it('Com campos obrigatórios vazios, a validação impede a criação e sinaliza os campos', async () => {
+    const res = await request(app)
+      .post('/admin/notification-templates')
+      .send({ tipo_evento: '', nome: '', conteudo: '' })
+      .expect(400);
+    expect(res.body).toHaveProperty('message');
+  });
+
+  it('Para um tipo de evento que já possui template ativo, impede a duplicidade', async () => {
+    const tipo = `${TEST_TIPO}-dup`;
+    await request(app)
+      .post('/admin/notification-templates')
+      .send({ tipo_evento: tipo, nome: 'Primeiro', conteudo: 'x' })
+      .expect(201);
+
+    const res = await request(app)
+      .post('/admin/notification-templates')
+      .send({ tipo_evento: tipo, nome: 'Segundo', conteudo: 'y' })
+      .expect(409);
+    expect(res.body).toHaveProperty('message');
+  });
+
+  it('Sem token válido retorna 401 sem executar a query', async () => {
+    const saved = process.env['ADMIN_AUTH_BYPASS'];
+    delete process.env['ADMIN_AUTH_BYPASS'];
+    try {
+      const res = await request(app)
+        .post('/admin/notification-templates')
+        .send({ tipo_evento: 'x', nome: 'y', conteudo: 'z' })
+        .expect(401);
+      expect(res.body).toEqual({ error: 'Unauthorized' });
+    } finally {
+      process.env['ADMIN_AUTH_BYPASS'] = saved;
+    }
+  });
+});
+
+describe('Suite de testes de integração — PATCH /api/admin/notification-templates/:id (RF56 · #202)', () => {
+  let id: string;
+
+  beforeAll(async () => {
+    const res = await request(app)
+      .post('/admin/notification-templates')
+      .send({ tipo_evento: `${TEST_TIPO}-edit`, nome: 'Original', conteudo: 'Original.' })
+      .expect(201);
+    id = res.body.id;
+  });
+
+  it('Edita o template existente sem duplicar o registro', async () => {
+    const res = await request(app)
+      .patch(`/admin/notification-templates/${id}`)
+      .send({ nome: 'Atualizado' })
+      .expect(200);
+
+    expect(res.body.id).toBe(id);
+    expect(res.body.nome).toBe('Atualizado');
+
+    const supabase = getSupabaseClient();
+    const { count } = await supabase
+      .from('notification_templates')
+      .select('*', { count: 'exact', head: true })
+      .eq('tipo_evento', `${TEST_TIPO}-edit`);
+    expect(count).toBe(1);
+  });
+
+  it('Com campos inválidos na edição, a validação impede e a versão anterior é mantida', async () => {
+    const res = await request(app)
+      .patch(`/admin/notification-templates/${id}`)
+      .send({ nome: '' })
+      .expect(400);
+    expect(res.body).toHaveProperty('message');
+
+    const supabase = getSupabaseClient();
+    const { data } = await supabase
+      .from('notification_templates')
+      .select('nome')
+      .eq('id', id)
+      .single();
+    expect(data?.nome).toBe('Atualizado');
+  });
+
+  it('Template inexistente retorna 404 sem efeito', async () => {
+    const res = await request(app)
+      .patch('/admin/notification-templates/00000000-0000-0000-0000-000000000000')
+      .send({ nome: 'x' })
+      .expect(404);
+    expect(res.body).toHaveProperty('message');
+  });
+});
+
+describe('Suite de testes de integração — DELETE /api/admin/notification-templates/:id (RF57 · #203)', () => {
+  let id: string;
+
+  beforeAll(async () => {
+    const res = await request(app)
+      .post('/admin/notification-templates')
+      .send({ tipo_evento: `${TEST_TIPO}-delete`, nome: 'A remover', conteudo: 'x' })
+      .expect(201);
+    id = res.body.id;
+  });
+
+  it('Remove (inativa) o template e retorna 200 com active=false', async () => {
+    const res = await request(app).delete(`/admin/notification-templates/${id}`).expect(200);
+    expect(res.body.active).toBe(false);
+  });
+
+  it('Template já removido retorna 404 de forma idempotente', async () => {
+    const res = await request(app).delete(`/admin/notification-templates/${id}`).expect(404);
+    expect(res.body).toHaveProperty('message');
+  });
+
+  it('id inexistente retorna 404', async () => {
+    const res = await request(app)
+      .delete('/admin/notification-templates/00000000-0000-0000-0000-000000000000')
+      .expect(404);
+    expect(res.body).toHaveProperty('message');
+  });
+
+  it('O template padrão de fallback não pode ser removido (409)', async () => {
+    const supabase = getSupabaseClient();
+    const { data: fallback } = await supabase
+      .from('notification_templates')
+      .select('id')
+      .eq('is_default', true)
+      .single();
+
+    const res = await request(app)
+      .delete(`/admin/notification-templates/${fallback?.id}`)
+      .expect(409);
+    expect(res.body).toHaveProperty('message');
+  });
+});
+
+describe('Suite de testes de integração — getTemplateForEvent (fallback, RF57 · #203)', () => {
+  it('Quando não há template ativo para o tipo de evento, resolve para o template padrão', async () => {
+    const template = await getTemplateForEvent(`${TEST_TIPO}-sem-template`);
+    expect(template?.is_default).toBe(true);
+  });
+
+  it('Quando há template ativo específico, resolve para ele em vez do padrão', async () => {
+    const tipo = `${TEST_TIPO}-fallback-especifico`;
+    await request(app)
+      .post('/admin/notification-templates')
+      .send({ tipo_evento: tipo, nome: 'Específico', conteudo: 'Específico.' })
+      .expect(201);
+
+    const template = await getTemplateForEvent(tipo);
+    expect(template?.tipo_evento).toBe(tipo);
+    expect(template?.is_default).toBe(false);
+  });
+});

--- a/backend/src/routes/index.ts
+++ b/backend/src/routes/index.ts
@@ -12,6 +12,7 @@ import { crmRouter } from '../crm/crm.routes.js';
 import { crmClientsRouter } from '../crm/crm-clients.routes.js';
 import { crmAdminClientsRouter } from '../crm/crm-admin-clients.routes.js';
 import { notificationsRouter } from '../notifications/notifications.routes.js';
+import { notificationTemplatesRouter } from '../notification-templates/notification-templates.routes.js';
 
 export const router = Router();
 
@@ -30,3 +31,4 @@ router.use('/crm', crmRouter);
 router.use('/crm/clients', crmClientsRouter);
 router.use('/crm/clients', clientsRouter);
 router.use('/admin/notifications', notificationsRouter);
+router.use('/admin/notification-templates', notificationTemplatesRouter);

--- a/frontend/src/routes/(admin)/+layout.svelte
+++ b/frontend/src/routes/(admin)/+layout.svelte
@@ -52,6 +52,12 @@
         { href: NAO_IMPL, label: 'Tickets', icon: Ticket, module: 'tickets' },
         { href: NAO_IMPL, label: 'Logs de Produtos', icon: FileText, module: 'productLogs' },
         { href: '/admin/notificacoes', label: 'Notificações', icon: Bell, module: 'notifications' },
+        {
+          href: '/admin/notification-templates',
+          label: 'Templates de Notificações',
+          icon: FileText,
+          module: 'notifications',
+        },
         { href: '/admin/membros', label: 'Membros', icon: Users, module: 'members' },
         { href: NAO_IMPL, label: 'Auditoria', icon: ShieldCheck, module: 'auditLogs' },
       ],

--- a/frontend/src/routes/(admin)/admin/notification-templates/+page.server.ts
+++ b/frontend/src/routes/(admin)/admin/notification-templates/+page.server.ts
@@ -1,0 +1,36 @@
+import { redirect } from '@sveltejs/kit';
+import { apiFetch } from '$lib/api/backend';
+import type { PageServerLoad } from './$types';
+
+export type NotificationTemplate = {
+  id: string;
+  tipo_evento: string;
+  nome: string;
+  conteudo: string;
+  is_default: boolean;
+  active: boolean;
+  created_at: string;
+  updated_at: string;
+};
+
+type TemplatesResponse = { templates: NotificationTemplate[] };
+
+export const load: PageServerLoad = async ({ cookies, locals }) => {
+  if (!locals.adminUser) throw redirect(303, '/admin/login');
+
+  const token = cookies.get('crianex_admin_access_token');
+  if (!token) throw redirect(303, '/admin/login');
+
+  try {
+    const data = await apiFetch<TemplatesResponse>('/admin/notification-templates', { token });
+    return { templates: data.templates ?? [] };
+  } catch (err) {
+    const apiError = err as { status?: number; message?: string };
+    if (apiError.status === 401) throw redirect(303, '/admin/login');
+    if (apiError.status === 403) return { templates: [], forbidden: true };
+    return {
+      templates: [],
+      error: apiError.message || 'Erro ao carregar templates de notificação.',
+    };
+  }
+};

--- a/frontend/src/routes/(admin)/admin/notification-templates/+page.svelte
+++ b/frontend/src/routes/(admin)/admin/notification-templates/+page.svelte
@@ -1,0 +1,491 @@
+<script lang="ts">
+  import { ShieldAlert, Pencil, Trash2, Star, Bell } from 'lucide-svelte';
+  import { onMount } from 'svelte';
+  import { topbarActions } from '$lib/stores/topbar';
+  import { page } from '$app/stores';
+  import { get } from 'svelte/store';
+  import { apiFetch, ApiError } from '$lib/api/backend';
+  import { tick } from 'svelte';
+  import { invalidateAll } from '$app/navigation';
+  import type { PageData } from './$types';
+  import type { NotificationTemplate } from './+page.server';
+  import TemplateModal from './templateModal.svelte';
+  import DeleteModal from './deleteModal.svelte';
+
+  export let data: PageData;
+
+  const emptyForm = { tipo_evento: '', nome: '', conteudo: '' };
+
+  let isModalOpen = false;
+  let isEditingMode = false;
+  let currentTemplateId: string | null = null;
+  let modalData = { ...emptyForm };
+  let modalError = '';
+
+  let isProcessing = false;
+  let processingMessage = '';
+
+  let toastMessage = '';
+  let toastVisible = false;
+  let toastTimer: ReturnType<typeof setTimeout> | null = null;
+
+  function showToast(msg: string) {
+    if (toastTimer) clearTimeout(toastTimer);
+    toastMessage = msg;
+    toastVisible = true;
+    toastTimer = setTimeout(() => {
+      toastVisible = false;
+    }, 3000);
+  }
+
+  $: _user = $page.data?.adminUser;
+  $: canEdit = _user?.role === 'owner' || (_user?.permissions?.notifications ?? []).includes('e');
+  $: canAdmin = _user?.role === 'owner' || (_user?.permissions?.notifications ?? []).includes('a');
+
+  onMount(() => {
+    const u = get(page).data?.adminUser;
+    const isAdmin = u?.role === 'owner' || (u?.permissions?.notifications ?? []).includes('e');
+    if (isAdmin) {
+      topbarActions.set([{ label: '+ Novo template', onClick: handleNovoTemplate }]);
+    }
+    return () => topbarActions.set([]);
+  });
+
+  function handleNovoTemplate() {
+    isEditingMode = false;
+    currentTemplateId = null;
+    modalData = { ...emptyForm };
+    modalError = '';
+    isModalOpen = true;
+  }
+
+  function handleEditarTemplate(template: NotificationTemplate) {
+    isEditingMode = true;
+    currentTemplateId = template.id;
+    modalData = {
+      tipo_evento: template.tipo_evento,
+      nome: template.nome,
+      conteudo: template.conteudo,
+    };
+    modalError = '';
+    isModalOpen = true;
+  }
+
+  async function handleSaveModal() {
+    modalError = '';
+
+    if (!modalData.tipo_evento.trim() || !modalData.nome.trim() || !modalData.conteudo.trim()) {
+      modalError = 'Preencha nome, tipo de evento e conteúdo.';
+      return;
+    }
+
+    try {
+      isProcessing = true;
+      processingMessage = isEditingMode ? 'Salvando alterações...' : 'Criando template...';
+
+      if (isEditingMode) {
+        await apiFetch(`/admin/notification-templates/${currentTemplateId}`, {
+          method: 'PATCH',
+          body: JSON.stringify({ nome: modalData.nome, conteudo: modalData.conteudo }),
+        });
+      } else {
+        await apiFetch('/admin/notification-templates', {
+          method: 'POST',
+          body: JSON.stringify(modalData),
+        });
+      }
+
+      isModalOpen = false;
+      await tick();
+      await invalidateAll();
+      showToast(
+        isEditingMode ? 'Template atualizado com sucesso!' : 'Template criado com sucesso!'
+      );
+    } catch (err) {
+      modalError =
+        err instanceof ApiError ? err.message : 'Falha ao salvar o template. Tente novamente.';
+    } finally {
+      isProcessing = false;
+    }
+  }
+
+  let listaTemplates: NotificationTemplate[] = [];
+  $: if (data.templates) {
+    listaTemplates = [...data.templates].sort((a, b) => a.tipo_evento.localeCompare(b.tipo_evento));
+  }
+
+  let showDeleteModal = false;
+  let templateIdToDelete: string | null = null;
+  let deleteError = '';
+
+  function openDeleteModal(id: string) {
+    templateIdToDelete = id;
+    deleteError = '';
+    showDeleteModal = true;
+  }
+
+  function closeDeleteModal() {
+    showDeleteModal = false;
+    templateIdToDelete = null;
+  }
+
+  $: templateToDeleteName = templateIdToDelete
+    ? (listaTemplates.find((t) => t.id === templateIdToDelete)?.nome ?? '')
+    : '';
+
+  async function handleExcluir() {
+    const idToDelete = templateIdToDelete;
+    if (!idToDelete) return;
+
+    closeDeleteModal();
+    await tick();
+
+    isProcessing = true;
+    processingMessage = 'Removendo template...';
+
+    try {
+      await apiFetch(`/admin/notification-templates/${idToDelete}`, { method: 'DELETE' });
+      await invalidateAll();
+      showToast('Template removido com sucesso!');
+    } catch (err) {
+      const msg =
+        err instanceof ApiError
+          ? err.message
+          : 'Não foi possível remover o template. Tente novamente.';
+      showToast(msg);
+    } finally {
+      isProcessing = false;
+    }
+  }
+</script>
+
+{#if toastVisible}
+  <div class="toast" role="status" aria-live="polite">
+    <svg
+      class="toast-icon"
+      fill="none"
+      viewBox="0 0 24 24"
+      stroke="currentColor"
+      stroke-width="2.5"
+    >
+      <path stroke-linecap="round" stroke-linejoin="round" d="M5 13l4 4L19 7" />
+    </svg>
+    {toastMessage}
+  </div>
+{/if}
+{#if isProcessing}
+  <div class="processing-overlay">
+    <div class="processing-card">
+      <svg class="spinner" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24">
+        <circle cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4" style="opacity:.25"
+        ></circle>
+        <path fill="currentColor" d="M4 12a8 8 0 018-8v4a4 4 0 00-4 4H4z" style="opacity:.75"
+        ></path>
+      </svg>
+      {processingMessage || 'Processando...'}
+    </div>
+  </div>
+{/if}
+
+<div class="admin-content">
+  {#if data.forbidden}
+    <div class="notif-state">
+      <span class="ico"><ShieldAlert size={22} /></span>
+      <div class="t">Acesso restrito</div>
+      <div class="s">Você não tem permissão para gerenciar templates de notificação.</div>
+    </div>
+  {:else}
+    <div class="panel">
+      <div class="panel-head">
+        <h3>
+          {listaTemplates.length} template{listaTemplates.length !== 1 ? 's' : ''} ativo{listaTemplates.length !==
+          1
+            ? 's'
+            : ''}
+        </h3>
+        <span class="grow"></span>
+        <span class="pill">CP9 · notificações</span>
+      </div>
+
+      {#if data.error}
+        <div class="error-bar">{data.error}</div>
+      {/if}
+
+      {#if listaTemplates.length === 0}
+        <div class="notif-state">
+          <span class="ico"><Bell size={22} /></span>
+          <div class="t">Nenhum template configurado</div>
+          <div class="s">Crie um template para padronizar notificações de um tipo de evento.</div>
+        </div>
+      {:else}
+        {#each listaTemplates as template (template.id)}
+          <div class="template-row">
+            <div class="t-meta">
+              <div class="t-name-row">
+                <span class="t-name">{template.nome}</span>
+                {#if template.is_default}
+                  <span class="pill default-pill"><Star size={10} /> padrão</span>
+                {/if}
+              </div>
+              <span class="t-desc">{template.conteudo}</span>
+            </div>
+            <span class="t-event mono">{template.tipo_evento}</span>
+
+            {#if canEdit || canAdmin}
+              <div class="t-actions">
+                {#if canEdit}
+                  <button
+                    type="button"
+                    class="icon-btn"
+                    title="Editar template"
+                    aria-label="Editar template"
+                    on:click={() => handleEditarTemplate(template)}
+                  >
+                    <Pencil size={14} />
+                  </button>
+                {/if}
+                {#if canAdmin && !template.is_default}
+                  <button
+                    type="button"
+                    class="icon-btn danger"
+                    title="Remover template"
+                    aria-label="Remover template"
+                    on:click={() => openDeleteModal(template.id)}
+                  >
+                    <Trash2 size={14} />
+                  </button>
+                {/if}
+              </div>
+            {/if}
+          </div>
+        {/each}
+      {/if}
+    </div>
+  {/if}
+</div>
+
+<TemplateModal
+  bind:isOpen={isModalOpen}
+  bind:isEditing={isEditingMode}
+  bind:formData={modalData}
+  errorMessage={modalError}
+  onSave={handleSaveModal}
+/>
+<DeleteModal isOpen={showDeleteModal} onClose={closeDeleteModal} onConfirm={handleExcluir}
+  >{templateToDeleteName}</DeleteModal
+>
+
+<style>
+  .admin-content {
+    padding: 22px 24px;
+    flex: 1;
+  }
+
+  .panel {
+    background: var(--bg-elev);
+    border: 1px solid var(--line);
+    border-radius: 10px;
+    overflow: hidden;
+  }
+
+  .panel-head {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+    padding: 14px 20px;
+    border-bottom: 1px solid var(--line);
+  }
+  .panel-head h3 {
+    margin: 0;
+    font-size: 13px;
+    font-weight: 500;
+    color: var(--text);
+  }
+  .grow {
+    flex: 1;
+  }
+  .pill {
+    font-family: var(--font-mono);
+    font-size: 10px;
+    letter-spacing: 0.06em;
+    padding: 3px 8px;
+    border-radius: 4px;
+    border: 1px solid var(--line);
+    color: var(--text-muted);
+    display: inline-flex;
+    align-items: center;
+    gap: 4px;
+  }
+  .default-pill {
+    background: rgba(234, 179, 8, 0.12);
+    color: #eab308;
+    border-color: rgba(234, 179, 8, 0.25);
+  }
+
+  .template-row {
+    display: grid;
+    grid-template-columns: 1fr 160px 72px;
+    gap: 16px;
+    align-items: center;
+    padding: 13px 20px;
+    border-bottom: 1px solid var(--line);
+  }
+  .template-row:last-of-type {
+    border-bottom: 0;
+  }
+  .template-row:hover {
+    background: var(--bg-soft);
+  }
+
+  .t-meta {
+    display: flex;
+    flex-direction: column;
+    gap: 2px;
+    min-width: 0;
+  }
+  .t-name-row {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+  }
+  .t-name {
+    font-size: 13.5px;
+    font-weight: 500;
+    color: var(--text);
+  }
+  .t-desc {
+    font-size: 11.5px;
+    color: var(--text-faint);
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+  }
+  .t-event {
+    font-size: 11px;
+    color: var(--text-muted);
+  }
+  .mono {
+    font-family: var(--font-mono);
+  }
+
+  .t-actions {
+    display: flex;
+    justify-content: flex-end;
+    gap: 6px;
+  }
+  .icon-btn {
+    width: 28px;
+    height: 28px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    border-radius: 6px;
+    background: transparent;
+    border: 0;
+    color: var(--text-faint);
+    cursor: pointer;
+    transition:
+      background 0.12s,
+      color 0.12s;
+  }
+  .icon-btn:hover {
+    background: var(--bg-tint);
+    color: var(--text);
+  }
+  .icon-btn.danger:hover {
+    background: rgba(244, 63, 94, 0.1);
+    color: #f43f5e;
+  }
+
+  .notif-state {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    text-align: center;
+    padding: 72px 20px;
+    color: var(--text-muted);
+  }
+  .notif-state .ico {
+    width: 48px;
+    height: 48px;
+    border-radius: 12px;
+    display: grid;
+    place-items: center;
+    background: var(--bg-soft);
+    border: 1px solid var(--line);
+    color: var(--text-faint);
+    margin-bottom: 12px;
+  }
+  .notif-state .t {
+    font-size: 14px;
+    color: var(--text);
+  }
+  .notif-state .s {
+    font-size: 12px;
+    margin-top: 4px;
+  }
+
+  .error-bar {
+    padding: 10px 20px;
+    font-size: 13px;
+    color: #f87171;
+    background: rgba(248, 113, 113, 0.08);
+    border-bottom: 1px solid rgba(248, 113, 113, 0.2);
+  }
+
+  .toast {
+    position: fixed;
+    bottom: 24px;
+    right: 24px;
+    z-index: 100;
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    padding: 12px 18px;
+    background: var(--bg-elev);
+    border: 1px solid var(--line);
+    border-radius: 10px;
+    font-size: 13px;
+    font-weight: 500;
+    color: var(--text);
+    box-shadow: var(--shadow-3);
+  }
+  .toast-icon {
+    width: 16px;
+    height: 16px;
+    color: var(--green);
+    flex-shrink: 0;
+  }
+
+  .processing-overlay {
+    position: fixed;
+    inset: 0;
+    z-index: 50;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    background: rgba(6, 6, 6, 0.5);
+  }
+  .processing-card {
+    display: flex;
+    align-items: center;
+    gap: 14px;
+    padding: 16px 24px;
+    background: var(--bg-elev);
+    border: 1px solid var(--line);
+    border-radius: 10px;
+    font-size: 13px;
+    color: var(--text);
+  }
+
+  @keyframes spin {
+    to {
+      transform: rotate(360deg);
+    }
+  }
+  .spinner {
+    width: 18px;
+    height: 18px;
+    animation: spin 0.8s linear infinite;
+  }
+</style>

--- a/frontend/src/routes/(admin)/admin/notification-templates/deleteModal.svelte
+++ b/frontend/src/routes/(admin)/admin/notification-templates/deleteModal.svelte
@@ -1,0 +1,215 @@
+<script lang="ts">
+  export let isOpen = false;
+  export let onClose: () => void;
+  export let onConfirm: () => void;
+
+  let dialogElement: HTMLDialogElement;
+
+  $: if (dialogElement) {
+    if (isOpen) {
+      dialogElement.showModal();
+    } else {
+      dialogElement.close();
+    }
+  }
+</script>
+
+<dialog bind:this={dialogElement} on:close={onClose}>
+  <div class="modal-wrapper">
+    <div class="header-close">
+      <button class="btn-close-top" aria-label="Fechar modal" on:click={onClose}>
+        <svg
+          xmlns="http://www.w3.org/2000/svg"
+          width="16"
+          height="16"
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          stroke-width="2"
+          stroke-linecap="round"
+          stroke-linejoin="round"
+          ><line x1="18" y1="6" x2="6" y2="18"></line><line x1="6" y1="6" x2="18" y2="18"
+          ></line></svg
+        >
+      </button>
+    </div>
+
+    <div class="txt">
+      <div class="primary-txt">Remover template?</div>
+      <p class="description-txt">
+        O template deixa de ser usado em novos disparos imediatamente. Notificações já enviadas com
+        este template não são afetadas. Esta ação não pode ser desfeita pela UI.
+      </p>
+
+      <div class="item-box">
+        <span class="item-label">Template:</span>
+        <span class="item-content"><slot /></span>
+      </div>
+    </div>
+
+    <div class="btn-group">
+      <button class="btn-cancel" on:click={onClose}>Cancelar</button>
+      <button class="btn-delete" on:click={onConfirm}>
+        <svg
+          xmlns="http://www.w3.org/2000/svg"
+          width="14"
+          height="14"
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          stroke-width="2.5"
+          stroke-linecap="round"
+          stroke-linejoin="round"
+          style="margin-right: 6px;"
+          ><line x1="18" y1="6" x2="6" y2="18"></line><line x1="6" y1="6" x2="18" y2="18"
+          ></line></svg
+        >
+        Remover template
+      </button>
+    </div>
+  </div>
+</dialog>
+
+<style>
+  dialog {
+    border: none;
+    border-radius: 16px;
+    padding: 0;
+    margin: auto;
+    width: calc(100% - 32px);
+    max-width: 440px;
+    background: #121214;
+    color: #f4f4f5;
+    box-shadow: 0 25px 50px -12px rgba(0, 0, 0, 0.7);
+    font-family: 'Inter', system-ui, sans-serif;
+    overflow: hidden;
+  }
+
+  dialog::backdrop {
+    background-color: rgba(0, 0, 0, 0.75);
+    backdrop-filter: blur(4px);
+  }
+
+  .modal-wrapper {
+    display: flex;
+    flex-direction: column;
+  }
+
+  .header-close {
+    padding: 24px 24px 0px 24px;
+    display: flex;
+    justify-content: flex-start;
+  }
+
+  .btn-close-top {
+    background: rgba(228, 32, 132, 0.12);
+    border: none;
+    color: #f43f5e;
+    width: 42px;
+    height: 42px;
+    border-radius: 10px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    cursor: pointer;
+    transition: background 0.2s;
+  }
+
+  .btn-close-top:hover {
+    background: rgba(228, 32, 132, 0.2);
+  }
+
+  .txt {
+    padding: 20px 24px;
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
+  }
+
+  .primary-txt {
+    font-size: 20px;
+    font-weight: 600;
+    color: #ffffff;
+    tracking-tight: -0.025em;
+  }
+
+  .description-txt {
+    font-size: 13.5px;
+    line-height: 1.5;
+    color: #94a3b8;
+    margin: 0;
+  }
+
+  .item-box {
+    background-color: #161619;
+    border-radius: 8px;
+    border: 1px solid #27272a;
+    padding: 12px 14px;
+    margin-top: 4px;
+    display: flex;
+    gap: 8px;
+    align-items: center;
+  }
+
+  .item-label {
+    font-family: monospace;
+    font-size: 12px;
+    color: #52525b;
+  }
+
+  .item-content {
+    font-family: monospace;
+    font-size: 13px;
+    font-weight: 600;
+    color: #ffffff;
+  }
+
+  .btn-group {
+    display: flex;
+    justify-content: flex-end;
+    align-items: center;
+    gap: 12px;
+    padding: 16px 24px 24px 24px;
+    border-top: 1px solid #212124;
+    background: #121214;
+  }
+
+  button {
+    font-family: 'Inter', sans-serif;
+    cursor: pointer;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    transition: all 0.15s ease;
+  }
+
+  .btn-cancel {
+    background: transparent;
+    color: #ffffff;
+    border: 1px solid #3f3f46;
+    border-radius: 9999px;
+    padding: 8px 20px;
+    font-size: 13px;
+    font-weight: 500;
+  }
+
+  .btn-cancel:hover {
+    background: #1c1c1f;
+    border-color: #52525b;
+  }
+
+  .btn-delete {
+    background-color: #e71f84;
+    color: #ffffff;
+    border: none;
+    border-radius: 9999px;
+    padding: 8px 20px;
+    font-size: 13px;
+    font-weight: 500;
+  }
+
+  .btn-delete:hover {
+    background-color: #be123c;
+    shadow: 0 4px 12px rgba(225, 29, 72, 0.3);
+  }
+</style>

--- a/frontend/src/routes/(admin)/admin/notification-templates/templateModal.svelte
+++ b/frontend/src/routes/(admin)/admin/notification-templates/templateModal.svelte
@@ -1,0 +1,319 @@
+<script lang="ts">
+  import { X } from 'lucide-svelte';
+
+  export let isOpen = false;
+  export let isEditing = false;
+  export let formData = {
+    tipo_evento: '',
+    nome: '',
+    conteudo: '',
+  };
+  export let errorMessage = '';
+  export let onSave: () => Promise<void>;
+
+  function fechar() {
+    isOpen = false;
+  }
+
+  async function submit(e: Event) {
+    e.preventDefault();
+    await onSave();
+  }
+</script>
+
+{#if isOpen}
+  <div class="overlay" role="dialog" aria-modal="true">
+    <div class="modal">
+      <button type="button" class="close-btn" on:click={fechar} aria-label="Fechar">
+        <X size={16} />
+      </button>
+
+      <form class="panel" on:submit={submit}>
+        <div class="breadcrumb">
+          <span>{isEditing ? 'Editar' : 'Criar'} · {formData.nome || 'Novo template'}</span>
+          <span class="sep">/</span><span class="crumb-active">notificações</span>
+        </div>
+
+        <div class="fields">
+          {#if errorMessage}
+            <div class="error-bar">{errorMessage}</div>
+          {/if}
+
+          <div class="field-group">
+            <span class="field-label">Nome do template</span>
+            <input
+              type="text"
+              class="field-input"
+              placeholder="Ex.: Novo lead capturado"
+              bind:value={formData.nome}
+              required
+            />
+          </div>
+
+          <div class="field-group">
+            <span class="field-label">Tipo de evento</span>
+            <input
+              type="text"
+              class="field-input"
+              placeholder="Ex.: novo_lead"
+              bind:value={formData.tipo_evento}
+              disabled={isEditing}
+              required
+            />
+            <span class="field-hint">
+              Identifica o evento do sistema que dispara este template. Apenas um template ativo por
+              tipo de evento.
+            </span>
+          </div>
+
+          <div class="field-group">
+            <span class="field-label">Conteúdo</span>
+            <textarea
+              rows="5"
+              class="field-input field-textarea"
+              placeholder="Texto da notificação exibido ao admin..."
+              bind:value={formData.conteudo}
+              required
+            ></textarea>
+          </div>
+        </div>
+
+        <div class="modal-footer">
+          <span class="footer-note"
+            >▲ Templates não removem histórico de notificações já enviadas</span
+          >
+          <div class="footer-actions">
+            <button type="button" class="btn-cancel" on:click={fechar}>Cancelar</button>
+            <button type="submit" class="btn-save"
+              >{isEditing ? 'Salvar alterações' : 'Criar template'}</button
+            >
+          </div>
+        </div>
+      </form>
+    </div>
+  </div>
+{/if}
+
+<style>
+  .overlay {
+    position: fixed;
+    inset: 0;
+    z-index: 200;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    padding: 24px;
+    background: rgba(0, 0, 0, 0.82);
+    backdrop-filter: blur(4px);
+    animation: fade-in 0.15s ease-out;
+  }
+  @keyframes fade-in {
+    from {
+      opacity: 0;
+    }
+    to {
+      opacity: 1;
+    }
+  }
+
+  .modal {
+    position: relative;
+    display: flex;
+    width: 100%;
+    max-width: 560px;
+    max-height: 90vh;
+    border-radius: 16px;
+    overflow: hidden;
+    border: 1px solid #2a2a2e;
+    box-shadow: 0 32px 64px rgba(0, 0, 0, 0.6);
+    animation: slide-in 0.18s cubic-bezier(0.16, 1, 0.3, 1);
+  }
+  @keyframes slide-in {
+    from {
+      opacity: 0;
+      transform: translateY(6px) scale(0.985);
+    }
+    to {
+      opacity: 1;
+      transform: none;
+    }
+  }
+
+  .close-btn {
+    position: absolute;
+    top: 14px;
+    right: 14px;
+    z-index: 10;
+    width: 28px;
+    height: 28px;
+    border-radius: 8px;
+    border: none;
+    background: rgba(255, 255, 255, 0.06);
+    color: #a1a1aa;
+    cursor: pointer;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    transition:
+      background 0.12s,
+      color 0.12s;
+  }
+  .close-btn:hover {
+    background: rgba(255, 255, 255, 0.12);
+    color: #f4f4f5;
+  }
+
+  .panel {
+    flex: 1;
+    min-width: 0;
+    background: #121214;
+    display: flex;
+    flex-direction: column;
+    overflow: hidden;
+  }
+
+  .breadcrumb {
+    padding: 16px 28px 12px;
+    font-size: 11px;
+    color: #52525b;
+    font-weight: 500;
+    display: flex;
+    align-items: center;
+    gap: 4px;
+    flex-shrink: 0;
+    border-bottom: 1px solid #1f1f23;
+  }
+  .sep {
+    color: #3f3f46;
+  }
+  .crumb-active {
+    color: #71717a;
+  }
+
+  .fields {
+    flex: 1;
+    overflow-y: auto;
+    padding: 20px 28px;
+    display: flex;
+    flex-direction: column;
+    gap: 18px;
+    scrollbar-width: thin;
+    scrollbar-color: #27272a transparent;
+  }
+
+  .field-group {
+    display: flex;
+    flex-direction: column;
+    gap: 7px;
+  }
+  .field-label {
+    font-size: 10px;
+    font-weight: 700;
+    letter-spacing: 0.1em;
+    text-transform: uppercase;
+    color: #52525b;
+  }
+  .field-hint {
+    font-size: 11px;
+    color: #52525b;
+    line-height: 1.4;
+  }
+
+  .field-input {
+    width: 100%;
+    background: #09090b;
+    border: 1px solid #27272a;
+    border-radius: 8px;
+    padding: 9px 12px;
+    font-size: 13.5px;
+    font-family: inherit;
+    color: #e4e4e7;
+    outline: none;
+    transition:
+      border-color 0.15s,
+      background 0.15s;
+    box-sizing: border-box;
+  }
+  .field-input:focus {
+    border-color: #52525b;
+    background: #050507;
+  }
+  .field-input::placeholder {
+    color: #3f3f46;
+  }
+  .field-input:disabled {
+    opacity: 0.5;
+    cursor: not-allowed;
+  }
+  .field-textarea {
+    resize: none;
+  }
+
+  .error-bar {
+    padding: 10px 12px;
+    font-size: 12.5px;
+    color: #f87171;
+    background: rgba(248, 113, 113, 0.08);
+    border: 1px solid rgba(248, 113, 113, 0.2);
+    border-radius: 8px;
+  }
+
+  .modal-footer {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    padding: 14px 28px;
+    border-top: 1px solid #1f1f23;
+    background: #121214;
+    flex-shrink: 0;
+    gap: 12px;
+  }
+  .footer-note {
+    font-size: 10px;
+    color: #3f3f46;
+    font-weight: 500;
+    letter-spacing: 0.06em;
+    text-transform: uppercase;
+  }
+  .footer-actions {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    flex-shrink: 0;
+  }
+
+  .btn-cancel {
+    border: 1px solid rgba(82, 82, 91, 0.5);
+    border-radius: 100px;
+    background: transparent;
+    color: #a1a1aa;
+    padding: 7px 18px;
+    font-size: 12px;
+    font-weight: 600;
+    font-family: inherit;
+    cursor: pointer;
+    transition:
+      background 0.12s,
+      color 0.12s;
+  }
+  .btn-cancel:hover {
+    background: #18181b;
+    color: #e4e4e7;
+  }
+
+  .btn-save {
+    border: none;
+    border-radius: 100px;
+    background: #f4f4f5;
+    color: #09090b;
+    padding: 7px 18px;
+    font-size: 12px;
+    font-weight: 700;
+    font-family: inherit;
+    cursor: pointer;
+    transition: background 0.12s;
+  }
+  .btn-save:hover {
+    background: #e4e4e7;
+  }
+</style>

--- a/supabase/migrations/20260701000100_create_notification_templates.sql
+++ b/supabase/migrations/20260701000100_create_notification_templates.sql
@@ -1,0 +1,39 @@
+-- Migration: create notification_templates table (F08 · CP9 — Sistema de Notificações)
+-- Ref: issue #180, sub-issue #201. Templates usados para padronizar o conteúdo de
+-- notificações geradas por eventos do sistema (F07/notifications).
+-- RLS: admin-only (app_metadata.role = 'owner'), igual a notifications (RNF09).
+
+CREATE TABLE public.notification_templates (
+  id          uuid        PRIMARY KEY DEFAULT gen_random_uuid(),
+  tipo_evento text        NOT NULL CHECK (length(trim(tipo_evento)) > 0),
+  nome        text        NOT NULL CHECK (length(trim(nome)) > 0),
+  conteudo    text        NOT NULL CHECK (length(trim(conteudo)) > 0),
+  is_default  boolean     NOT NULL DEFAULT false,
+  active      boolean     NOT NULL DEFAULT true,
+  created_at  timestamptz NOT NULL DEFAULT now(),
+  updated_at  timestamptz NOT NULL DEFAULT now()
+);
+
+-- Impede duplicidade: no máximo 1 template ATIVO por tipo_evento (RF15).
+-- Templates inativados não contam, então um tipo_evento pode ter histórico de
+-- templates inativos sem bloquear a criação de um novo ativo.
+CREATE UNIQUE INDEX notification_templates_tipo_evento_active_idx
+  ON public.notification_templates (tipo_evento)
+  WHERE active;
+
+-- Auto-bump updated_at (mesmo padrão de crm_columns/products)
+CREATE TRIGGER notification_templates_updated_at
+  BEFORE UPDATE ON public.notification_templates
+  FOR EACH ROW EXECUTE FUNCTION extensions.moddatetime(updated_at);
+
+GRANT ALL ON public.notification_templates TO service_role;
+GRANT SELECT, INSERT, UPDATE, DELETE ON public.notification_templates TO authenticated;
+REVOKE ALL ON public.notification_templates FROM anon;
+
+ALTER TABLE public.notification_templates ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY notification_templates_owner_all ON public.notification_templates
+  FOR ALL
+  TO authenticated
+  USING      ((SELECT auth.jwt()) -> 'app_metadata' ->> 'role' = 'owner')
+  WITH CHECK ((SELECT auth.jwt()) -> 'app_metadata' ->> 'role' = 'owner');

--- a/supabase/migrations/20260701000200_seed_default_notification_template.sql
+++ b/supabase/migrations/20260701000200_seed_default_notification_template.sql
@@ -1,0 +1,9 @@
+-- Seed: template padrão de fallback para notificações (F08 — issue #205)
+-- Idempotente: só insere quando não existe nenhum template com is_default=true,
+-- garantindo que a remoção de um template específico sempre recaia em um
+-- fallback funcional (RF57), mesmo em um ambiente recém-provisionado.
+
+INSERT INTO public.notification_templates (tipo_evento, nome, conteudo, is_default, active)
+SELECT '__default__', 'Template padrão de fallback',
+       'Um evento do tipo {{tipo_evento}} ocorreu.', true, true
+WHERE NOT EXISTS (SELECT 1 FROM public.notification_templates WHERE is_default = true);

--- a/supabase/tests/notification_templates_test.sql
+++ b/supabase/tests/notification_templates_test.sql
@@ -1,0 +1,81 @@
+-- pgTAP tests for notification_templates table (F08 · issue #180, sub-issue #201)
+-- Run with: supabase test db
+BEGIN;
+
+SELECT plan(19);
+
+-- ── Schema: notification_templates ──────────────────────────────────────────────
+SELECT has_table('public', 'notification_templates', 'notification_templates table exists');
+
+SELECT has_column('public', 'notification_templates', 'id',          'has id');
+SELECT has_column('public', 'notification_templates', 'tipo_evento', 'has tipo_evento');
+SELECT has_column('public', 'notification_templates', 'nome',        'has nome');
+SELECT has_column('public', 'notification_templates', 'conteudo',    'has conteudo');
+SELECT has_column('public', 'notification_templates', 'is_default',  'has is_default');
+SELECT has_column('public', 'notification_templates', 'active',      'has active');
+
+SELECT col_not_null('public', 'notification_templates', 'tipo_evento', 'tipo_evento is NOT NULL');
+SELECT col_not_null('public', 'notification_templates', 'nome',        'nome is NOT NULL');
+SELECT col_not_null('public', 'notification_templates', 'conteudo',    'conteudo is NOT NULL');
+
+SELECT col_default_is('public', 'notification_templates', 'active', 'true',
+  'active defaults to true');
+SELECT col_default_is('public', 'notification_templates', 'is_default', 'false',
+  'is_default defaults to false');
+
+-- ── RLS enabled ──────────────────────────────────────────────────────────────────
+SELECT ok(
+  (SELECT relrowsecurity FROM pg_class
+   WHERE relname = 'notification_templates' AND relnamespace = 'public'::regnamespace),
+  'RLS is enabled on notification_templates'
+);
+
+-- ── Policy & privileges (RNF09 — admin-only) ─────────────────────────────────────
+SELECT ok(
+  EXISTS (SELECT 1 FROM pg_policies
+          WHERE schemaname = 'public' AND tablename = 'notification_templates'
+            AND policyname = 'notification_templates_owner_all'),
+  'owner-only policy exists on notification_templates'
+);
+
+SELECT ok(NOT has_table_privilege('anon', 'public.notification_templates', 'SELECT'),
+  'anon has no SELECT on notification_templates');
+SELECT ok(has_table_privilege('authenticated', 'public.notification_templates', 'INSERT'),
+  'authenticated has INSERT on notification_templates');
+
+-- ── Constraints ───────────────────────────────────────────────────────────────────
+SELECT throws_ok(
+  $$INSERT INTO public.notification_templates (tipo_evento, nome, conteudo)
+    VALUES ('', 'x', 'y')$$,
+  '23514',
+  NULL,
+  'empty tipo_evento rejected by CHECK constraint'
+);
+
+-- ── Duplicidade (RF15): no máximo 1 ativo por tipo_evento ────────────────────────
+INSERT INTO public.notification_templates (tipo_evento, nome, conteudo)
+VALUES ('novo_lead', 'Novo lead', 'Um novo lead chegou.');
+
+SELECT throws_ok(
+  $$INSERT INTO public.notification_templates (tipo_evento, nome, conteudo)
+    VALUES ('novo_lead', 'Duplicado', 'Outro texto')$$,
+  '23505',
+  NULL,
+  'segundo template ativo para o mesmo tipo_evento é rejeitado'
+);
+
+-- inativar o template libera o tipo_evento para um novo ativo
+UPDATE public.notification_templates SET active = false WHERE tipo_evento = 'novo_lead';
+
+INSERT INTO public.notification_templates (tipo_evento, nome, conteudo)
+VALUES ('novo_lead', 'Novo lead v2', 'Texto atualizado.');
+
+SELECT is(
+  (SELECT count(*)::int FROM public.notification_templates
+   WHERE tipo_evento = 'novo_lead' AND active = true),
+  1,
+  'após inativar o antigo, um novo template ativo pode ser criado para o mesmo evento'
+);
+
+SELECT * FROM finish();
+ROLLBACK;


### PR DESCRIPTION
## Summary
Implementa a feature #180 — F08 Gerenciar templates de notificações — cobrindo todas as sub-issues e critérios de aceite:

- **#201** — Migration `notification_templates` (id, tipo_evento, nome, conteudo, is_default, active) com RLS admin-only (`app_metadata.role = 'owner'`, mesmo padrão de `notifications`) e índice único parcial `(tipo_evento) WHERE active` que impede mais de um template ativo por tipo de evento (RF15).
- **#205** — Seed idempotente do template padrão de fallback (`is_default = true`), garantindo que qualquer ambiente novo tenha um fallback funcional desde o primeiro deploy.
- **#202** — `POST /api/admin/notification-templates` e `PATCH /api/admin/notification-templates/:id` (RF15, RF56), com validação de campos obrigatórios e resposta 409 em duplicidade de `tipo_evento`.
- **#203** — `DELETE /api/admin/notification-templates/:id` (RF57) como inativação lógica (`active=false`, nunca DELETE físico), idempotente (404 em remoção repetida), com `getTemplateForEvent()` resolvendo o fallback quando não há template ativo específico. O template padrão é protegido contra remoção (409).
- **#204** — Tela admin (`/admin/notification-templates`): listagem de templates ativos, modal de criação/edição e confirmação de remoção, reaproveitando o padrão visual de `admin/products`.

Todas as Definitions of Ready e os critérios de aceite (RF15/RF56/RF57) foram marcados como concluídos na descrição da issue #180.

## Test plan
- [x] `supabase test db` — 19 novas assertions pgTAP em `notification_templates_test.sql` (schema, RLS, grants, constraints, anti-duplicidade), suite completa (130 testes) passa
- [x] `vitest run` backend — 13 novos testes de integração (POST/PATCH/DELETE + fallback), suite completa (126 testes) passa
- [x] `vitest run` frontend — suite completa (105 testes) passa
- [x] `tsc --noEmit` backend e frontend (via `svelte-kit sync`) sem erros
- [x] `eslint` backend e frontend sem novos erros (apenas warnings pré-existentes)
- [x] `prettier --check .` na raiz do repo — sem problemas
- [x] `vite build` (frontend) e `tsc` (backend) — build OK
- [x] Smoke test manual via curl no backend local apontando para Supabase local